### PR TITLE
fix: index tool calls from resolved span output, not _io_messages

### DIFF
--- a/backend/tests/test_otel_mapping.py
+++ b/backend/tests/test_otel_mapping.py
@@ -672,3 +672,44 @@ def test_an_array_shaped_tool_input_is_not_overwritten():
     tool["input"] = '["already", "recorded"]'
     _enrich_tool_io(events)
     assert json.loads(tool["input"]) == ["already", "recorded"]
+
+
+def test_tool_calls_indexed_from_a_bare_output_dict() -> None:
+    """`tracely.output` bypasses `_io_messages` entirely — a single (unlisted) message dict must
+    still index its tool calls, or `missing_tools` can never fire."""
+    e = _event(
+        {
+            "gen_ai.request.model": "gpt-4o",
+            "tracely.output": json.dumps(
+                {
+                    "content": "on it",
+                    "tool_calls": [
+                        {"id": "c1", "type": "function",
+                         "function": {"name": "search", "arguments": '{"q": "x"}'}}
+                    ],
+                }
+            ),
+        }
+    )
+    assert e["tool_call_names"] == ["search"]
+
+
+def test_tool_calls_indexed_from_anthropic_tool_use_blocks() -> None:
+    e = _event(
+        {
+            "gen_ai.request.model": "claude-sonnet-4",
+            "gen_ai.output.messages": json.dumps(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "checking"},
+                            {"type": "tool_use", "id": "tu_1", "name": "get_weather",
+                             "input": {"city": "SF"}},
+                        ],
+                    }
+                ]
+            ),
+        }
+    )
+    assert e["tool_call_names"] == ["get_weather"]

--- a/backend/tracely/otel/span_mapper.py
+++ b/backend/tracely/otel/span_mapper.py
@@ -193,7 +193,7 @@ def _map_span(
         ),
         "model_parameters": _model_parameters(a),
         "usage_details": _usage(a),
-        "tool_call_names": _tool_call_names(a, otype),
+        "tool_call_names": _tool_call_names(a, otype, span_output),
         "input": span_input,
         "output": span_output,
         "metadata": {

--- a/backend/tracely/otel/tool_enrichment.py
+++ b/backend/tracely/otel/tool_enrichment.py
@@ -15,23 +15,23 @@ import json
 from typing import Any
 
 from tracely.otel.attributes import _first, _to_str
-from tracely.otel.messages import _io_messages
 from tracely.otel.types import GENERATION, TOOL
 
 
-def _tool_call_names(attrs: dict[str, Any], otype: str) -> list[str]:
+def _tool_call_names(attrs: dict[str, Any], otype: str, output: str | None = None) -> list[str]:
     """Tools the model requested. Explicit `tracely.tool_calls` (array) wins; else the function
-    names reassembled from output-message tool calls (any convention); else the tool name on a
-    TOOL span."""
+    names parsed out of the span's RESOLVED output (`_io_field`, i.e. what we actually store);
+    else the tool name on a TOOL span.
+
+    Reading the resolved output rather than re-deriving from `_io_messages` is the point: the
+    manual `tracely.output` / `langfuse.observation.output` escape hatches never go through
+    `_io_messages`, so a plain `{"content": …, "tool_calls": […]}` dict indexed nothing — and an
+    empty `tool_call_names` silently kills `missing_tools` in `domain/traces/spans.py`.
+    """
     tc = attrs.get("tracely.tool_calls")
     if isinstance(tc, list):
         return [str(x) for x in tc if x]
-    names: list[str] = []
-    for m in _io_messages(attrs, "output") or []:
-        for call in m.get("tool_calls") or []:
-            fn = (call.get("function") or {}).get("name") if isinstance(call, dict) else None
-            if fn:
-                names.append(str(fn))
+    names = [c["name"] for c in _extract_tool_calls(output or "")]
     if names:
         return names
     name = _first(attrs, ["gen_ai.tool.name", "tool.name"])
@@ -52,6 +52,14 @@ def _extract_tool_calls(output_str: str) -> list[dict[str, Any]]:
     for m in msgs:
         if not isinstance(m, dict):
             continue
+        # Anthropic-style content blocks: `{"type":"tool_use","name":…,"input":{…}}`.
+        for block in m.get("content") if isinstance(m.get("content"), list) else []:
+            if isinstance(block, dict) and block.get("type") == "tool_use" and block.get("name"):
+                out.append({
+                    "id": block.get("id"),
+                    "name": str(block["name"]),
+                    "args": block.get("input"),
+                })
         for tc in m.get("tool_calls") or []:
             if not isinstance(tc, dict):
                 continue


### PR DESCRIPTION
`_tool_call_names` re-derived tool calls from `_io_messages`, which the manual `tracely.output` / `langfuse.observation.output` escape hatches never go through. A plain `{"content": …, "tool_calls": […]}` dict indexed nothing — and an empty `tool_call_names` silently disables `missing_tools` in `domain/traces/spans.py` rather than failing loudly.

Parses the resolved span output instead (what we actually store), and teaches `_extract_tool_calls` about Anthropic `tool_use` content blocks.

Two regression tests cover both paths. `775 passed, 30 skipped`; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)