### PR TITLE
chore(domain): move the site to tracely-ai.com, 308 the old .xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ that would ship them again — and tells you the moment any of it happens.
 <code>production trace</code> → <code>failure detection</code> → <code>regression test</code> → <code>CI gate</code> → <code>alert</code>
 </p>
 
-[**Website**](https://tracely-studio.xyz) · [**Docs**](https://doc.tracely-studio.xyz) · [**Product guide**](https://doc.tracely-studio.xyz/product) · [**Agent skill**](#teach-your-coding-agent-tracely) · [**Guided tour**](guides/OVERVIEW.md) · [**2-min demo**](guides/DEMO.md) · [**Design dossier**](design/README.md)
+[**Website**](https://tracely-ai.com) · [**Docs**](https://doc.tracely-ai.com) · [**Product guide**](https://doc.tracely-ai.com/product) · [**Agent skill**](#teach-your-coding-agent-tracely) · [**Guided tour**](guides/OVERVIEW.md) · [**2-min demo**](guides/DEMO.md) · [**Design dossier**](design/README.md)
 
 [![CI](https://github.com/Jwuthri/Tracely/actions/workflows/ci.yml/badge.svg)](https://github.com/Jwuthri/Tracely/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/tracely-ai?logo=pypi&logoColor=white)](https://pypi.org/project/tracely-ai/) [![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)](https://pypi.org/project/tracely-ai/) [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE) [![Stars](https://img.shields.io/github/stars/Jwuthri/Tracely?style=flat&logo=github)](https://github.com/Jwuthri/Tracely/stargazers)
 
@@ -142,18 +142,18 @@ over-flagging judge *before* you let it gate a release.
 | | What it does | Where |
 |---|---|---|
 | **Ingest** | OTLP/HTTP from any language; blob-first durability (S3 before the queue); agent semantics as indexed columns; three message conventions normalized | [`backend/`](backend/README.md) |
-| **Evaluators** | Columns on the trace table. Structural checks (no model) + LLM judges at conversation / run / span level, multi-output (score, boolean, number, text, JSON schema), basic or `@VARIABLE` advanced prompts with live preview, batch or sequential, per-agent/env targeting, deterministic sampling, advisory verdicts | [Docs](https://doc.tracely-studio.xyz/product/traces) |
-| **Failure clusters** | Structural signature + semantic embedding clustering, taxonomy, suggested evaluators, promote-to-case | [Docs](https://doc.tracely-studio.xyz/product/clusters) |
-| **Regression cases** | Hermetic fixture bundles, fail-to-pass contracts, assertions, reference trajectory, replay history | [Docs](https://doc.tracely-studio.xyz/product/cases) |
-| **Scenarios** | Multi-turn conversations Tracely drives at your agent's own endpoint, or an adversarial goal a red-team model pursues (goal achieved = FAIL) | [Docs](https://doc.tracely-studio.xyz/product/scenarios) |
-| **CI gates** | `tracely simulate` / `replay` / `gate` + a GitHub Action: commit status, PR comment, non-zero exit | [Docs](https://doc.tracely-studio.xyz/product/gates) |
-| **Alerts** | Trigger + visual flow: conditions, Slack, email, webhooks with headers, an LLM step, Python expressions. Event triggers fire inline; thresholds poll a window. Test runs show what each step actually sent | [Docs](https://doc.tracely-studio.xyz/product/alerts) |
-| **Trends & analysis** | Daily traces/failures/gate pass-rate, latency + cost, per-agent cross-metric meta-analysis | [Docs](https://doc.tracely-studio.xyz/product/trends) |
-| **Judge calibration** | Label judge verdicts against human review; per-evaluator agreement, missed failures vs over-flagging | [Docs](https://doc.tracely-studio.xyz/product/calibration) |
-| **Conversation intelligence** | Rolling per-turn summary (backs the judge's `@HISTORY`), declared agent catalog, state deltas, Replay + Fleet views, shareable read-only links | [Docs](https://doc.tracely-studio.xyz/product/traces) |
-| **In-app assistant** | ⌘J — an agent over *your* workspace: reads traces, creates evaluators, scenarios, cases and alerts, as you. ⌘K jumps anywhere | [Docs](https://doc.tracely-studio.xyz/product/assistant) |
-| **MCP server** | The API doubles as an MCP endpoint (`/mcp`) so a coding agent drives the workspace with an ordinary ingest key | [Docs](https://doc.tracely-studio.xyz/mcp) |
-| **Auth & teams** | `dev` (open) · `local` (email/password + invites) · `clerk`. Organizations, workspaces, seats, API keys, per-workspace OpenRouter key | [Docs](https://doc.tracely-studio.xyz/product/settings) |
+| **Evaluators** | Columns on the trace table. Structural checks (no model) + LLM judges at conversation / run / span level, multi-output (score, boolean, number, text, JSON schema), basic or `@VARIABLE` advanced prompts with live preview, batch or sequential, per-agent/env targeting, deterministic sampling, advisory verdicts | [Docs](https://doc.tracely-ai.com/product/traces) |
+| **Failure clusters** | Structural signature + semantic embedding clustering, taxonomy, suggested evaluators, promote-to-case | [Docs](https://doc.tracely-ai.com/product/clusters) |
+| **Regression cases** | Hermetic fixture bundles, fail-to-pass contracts, assertions, reference trajectory, replay history | [Docs](https://doc.tracely-ai.com/product/cases) |
+| **Scenarios** | Multi-turn conversations Tracely drives at your agent's own endpoint, or an adversarial goal a red-team model pursues (goal achieved = FAIL) | [Docs](https://doc.tracely-ai.com/product/scenarios) |
+| **CI gates** | `tracely simulate` / `replay` / `gate` + a GitHub Action: commit status, PR comment, non-zero exit | [Docs](https://doc.tracely-ai.com/product/gates) |
+| **Alerts** | Trigger + visual flow: conditions, Slack, email, webhooks with headers, an LLM step, Python expressions. Event triggers fire inline; thresholds poll a window. Test runs show what each step actually sent | [Docs](https://doc.tracely-ai.com/product/alerts) |
+| **Trends & analysis** | Daily traces/failures/gate pass-rate, latency + cost, per-agent cross-metric meta-analysis | [Docs](https://doc.tracely-ai.com/product/trends) |
+| **Judge calibration** | Label judge verdicts against human review; per-evaluator agreement, missed failures vs over-flagging | [Docs](https://doc.tracely-ai.com/product/calibration) |
+| **Conversation intelligence** | Rolling per-turn summary (backs the judge's `@HISTORY`), declared agent catalog, state deltas, Replay + Fleet views, shareable read-only links | [Docs](https://doc.tracely-ai.com/product/traces) |
+| **In-app assistant** | ⌘J — an agent over *your* workspace: reads traces, creates evaluators, scenarios, cases and alerts, as you. ⌘K jumps anywhere | [Docs](https://doc.tracely-ai.com/product/assistant) |
+| **MCP server** | The API doubles as an MCP endpoint (`/mcp`) so a coding agent drives the workspace with an ordinary ingest key | [Docs](https://doc.tracely-ai.com/mcp) |
+| **Auth & teams** | `dev` (open) · `local` (email/password + invites) · `clerk`. Organizations, workspaces, seats, API keys, per-workspace OpenRouter key | [Docs](https://doc.tracely-ai.com/product/settings) |
 | **Ops** | Beat self-check (queue depth, worker liveness, ingest freshness) + `/health/queue`, optional Sentry, optional trace quota + Stripe billing | [`guides/DEPLOY.md`](guides/DEPLOY.md) |
 
 Near-term plan: [design/part2-tracely/11-prd-next-steps.md](design/part2-tracely/11-prd-next-steps.md) ·
@@ -287,7 +287,7 @@ non-Python services can push the catalog with `POST /api/sessions/{conversation_
 
 </details>
 
-Full instrumentation guide → **[doc.tracely-studio.xyz](https://doc.tracely-studio.xyz)** · [`sdk/README.md`](sdk/README.md)
+Full instrumentation guide → **[doc.tracely-ai.com](https://doc.tracely-ai.com)** · [`sdk/README.md`](sdk/README.md)
 
 ---
 
@@ -300,7 +300,7 @@ wire it, depending on how your CI can reach your agent.
 <details open>
 <summary><b>Option A — let Tracely call your agent</b> (no agent code in CI, any language)</summary>
 
-Register your agent's HTTP endpoint once, author [scenarios](https://doc.tracely-studio.xyz/product/scenarios) —
+Register your agent's HTTP endpoint once, author [scenarios](https://doc.tracely-ai.com/product/scenarios) —
 multi-turn conversations, or an adversarial goal a red-team model improvises against — and Tracely
 drives them itself. **Nothing to install, import or shim**, so a TypeScript or Go service gates exactly
 like a Python one.
@@ -397,9 +397,9 @@ each step actually sent, after templating.
 
 <img src=".github/assets/alerts.png" alt="The alerts list — a gallery of use cases, and rules showing their trigger and their flow as a strip of steps" width="100%" />
 
-The same rules are reachable from the [in-app assistant](https://doc.tracely-studio.xyz/product/assistant)
+The same rules are reachable from the [in-app assistant](https://doc.tracely-ai.com/product/assistant)
 (*"Slack me when the refund judge fails a conversation"*) and from the MCP server, so an agent can
-arm one for you. [Alerts guide →](https://doc.tracely-studio.xyz/product/alerts)
+arm one for you. [Alerts guide →](https://doc.tracely-ai.com/product/alerts)
 
 ---
 
@@ -416,7 +416,7 @@ claude mcp add --transport http tracely http://localhost:8000/mcp \
 Then: *"look at the last 20 traces, find what's failing, and add an evaluation column that catches
 it."* Tools over traces, failure clusters, evaluators and trends — scoped to the key's workspace,
 same as every other call. On hosted Tracely the endpoint is
-`https://api.tracely-studio.xyz/mcp`. [Docs](https://doc.tracely-studio.xyz/mcp)
+`https://api.tracely-ai.com/mcp`. [Docs](https://doc.tracely-ai.com/mcp)
 
 ---
 
@@ -539,7 +539,7 @@ cd frontend && pnpm test && pnpm build      # vitest + tsc typecheck + lint
 
 <div align="center">
 
-**[tracely-studio.xyz](https://tracely-studio.xyz)** · [Docs](https://doc.tracely-studio.xyz) · [Product guide](https://doc.tracely-studio.xyz/product) · [Star on GitHub](https://github.com/Jwuthri/Tracely)
+**[tracely-ai.com](https://tracely-ai.com)** · [Docs](https://doc.tracely-ai.com) · [Product guide](https://doc.tracely-ai.com/product) · [Star on GitHub](https://github.com/Jwuthri/Tracely)
 
 If Tracely is useful to you, a ⭐ helps other people find it.
 

--- a/design/GROWTH.md
+++ b/design/GROWTH.md
@@ -73,9 +73,9 @@ Every item here costs $0. Verified 2026-08-15: OpenAlternative is no longer on t
 
 ```
 Name:        Tracely
-URL:         https://tracely-studio.xyz
+URL:         https://tracely-ai.com
 GitHub:      https://github.com/Jwuthri/Tracely
-Docs:        https://doc.tracely-studio.xyz
+Docs:        https://doc.tracely-ai.com
 License:     MIT · self-hostable · Python SDK: pip install tracely-ai
 
 Tagline (60):  Production agent failures become CI regression tests
@@ -180,12 +180,12 @@ Both are PR/CLI flows, not web forms. Verified 2026-08-15.
 ### 8a. MCP registry (~30 min)
 
 `server.json` is already written at the repo root. It declares the remote server at
-`https://api.tracely-studio.xyz/mcp` (streamable HTTP — matches `api/mcp_server.py`).
+`https://api.tracely-ai.com/mcp` (streamable HTTP — matches `api/mcp_server.py`).
 
 Use **GitHub auth**, not DNS auth: DNS requires an apex TXT record and an Ed25519 key, and macOS
 ships LibreSSL which can't generate one without `brew install openssl@3`. GitHub auth is an OAuth
 prompt. The trade-off is the name — GitHub auth forces `io.github.jwuthri/tracely`; DNS auth would
-let you own `xyz.tracely-studio/tracely`. Not worth the yak-shave now; you can republish under the
+let you own `com.tracely-ai/tracely`. Not worth the yak-shave now; you can republish under the
 domain name later if it ever matters.
 
 ```bash
@@ -194,7 +194,7 @@ mcp-publisher login github      # opens an OAuth prompt; needs no repo scopes
 mcp-publisher publish           # reads ./server.json
 ```
 
-Preconditions: `https://api.tracely-studio.xyz/mcp` must be publicly reachable. It answers 401
+Preconditions: `https://api.tracely-ai.com/mcp` must be publicly reachable. It answers 401
 without an `Authorization: Bearer <ingest-key>` header — that's fine and normal for remote servers,
 but the host has to resolve and respond. Check before publishing.
 
@@ -222,8 +222,8 @@ tags:
   - langchain
 urls:
   repo: https://github.com/Jwuthri/Tracely
-  website: https://tracely-studio.xyz
-  docs: https://doc.tracely-studio.xyz
+  website: https://tracely-ai.com
+  docs: https://doc.tracely-ai.com
 license: MIT
 description:
   Auto-instruments AI agent frameworks and LLM SDKs (OpenAI, Anthropic, LangChain, LlamaIndex,

--- a/design/SEO.md
+++ b/design/SEO.md
@@ -1,4 +1,4 @@
-# SEO plan — tracely-studio.xyz
+# SEO plan — tracely-ai.com
 
 Working document. Phase 1 shipped 2026-08-11 (commit `93dff69`). Phase 2 (keyword research) completed
 2026-08-12 against live DataForSEO data — **185 of 500 OpenSEO credits spent, 315 remaining.**
@@ -186,7 +186,7 @@ That's the single highest-value backlink action available, and it's a PR to a do
 outreach. Pair each one with the matching `/integrations/<framework>` page from Tier 3.
 
 **2. Package registries.** `pypi.org` and `npmjs.com` both link to Langfuse. `tracely-ai` is on
-PyPI already — make sure the package metadata points at `tracely-studio.xyz`, not just the repo.
+PyPI already — make sure the package metadata points at `tracely-ai.com`, not just the repo.
 Free link, already earned, possibly not claimed.
 
 **3. Self-host and OSS directories.** `selfhost.directory`, `saashub.com`, `webcatalog.io`,
@@ -246,7 +246,7 @@ is needed sooner, that's Phase 4, not more pages.
 
 ## 5. Deferred, on purpose
 
-- **`doc.tracely-studio.xyz` → `/docs`** — real win (docs attract the links; on a subdomain that
+- **`doc.tracely-ai.com` → `/docs`** — real win (docs attract the links; on a subdomain that
   authority doesn't fully flow to root) but a genuine migration with redirects. Revisit once the
   docs have inbound links worth consolidating.
 - **MDX blog pipeline** — at post #10.
@@ -261,7 +261,7 @@ is needed sooner, that's Phase 4, not more pages.
 1. **Link Search Console inside OpenSEO** — unlocks `get_search_console_performance`, `inspect_urls`,
    `get_search_opportunities`. Without it I work from third-party estimates.
 2. **Submit the sitemap** in GSC → Sitemaps; Request Indexing on the homepage.
-3. **Inspect `doc.tracely-studio.xyz`** — those 11 pages just got titles for the first time.
+3. **Inspect `doc.tracely-ai.com`** — those 11 pages just got titles for the first time.
 4. **Bing Webmaster Tools** — import from GSC. Also feeds ChatGPT's web search.
 5. **Approve the comparison-page claims** before they publish. I can describe what Langfuse and
    LangSmith do; publicly asserting a competitor's limitation is your call.

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -6,6 +6,18 @@ const withNextra = nextra({
   defaultShowCopyCode: true,
 });
 
+// doc.tracely-studio.xyz stays attached to this service and 308s here — see frontend/next.config.mjs
+// for why the old domain is kept alive rather than detached.
 export default withNextra({
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "doc.tracely-studio.xyz" }],
+        destination: "https://doc.tracely-ai.com/:path*",
+        permanent: true,
+      },
+    ];
+  },
 });

--- a/docs/pages/claude-code.mdx
+++ b/docs/pages/claude-code.mdx
@@ -47,7 +47,7 @@ Add this to `~/.claude/settings.json` (all sessions) or a project's `.claude/set
 ```
 
 Point `OTEL_EXPORTER_OTLP_ENDPOINT` at your Tracely **API host** — the exporter appends `/v1/traces`
-itself. Hosted: `https://api.tracely-studio.xyz`. Self-hosted docker-compose: `http://localhost:8000`.
+itself. Hosted: `https://api.tracely-ai.com`. Self-hosted docker-compose: `http://localhost:8000`.
 The header value is one of your workspace's [ingest keys](/product/settings) — the same key the SDK
 sends, and the thing that decides which workspace the session lands in.
 

--- a/docs/pages/evaluations.mdx
+++ b/docs/pages/evaluations.mdx
@@ -50,7 +50,7 @@ schema, built in the Add Column form. Enum fields are enforced on the model, and
 
 ## Further reading
 
-New to this? [LLM evaluation: metrics, methods and tools](https://tracely-studio.xyz/llm-evaluation)
+New to this? [LLM evaluation: metrics, methods and tools](https://tracely-ai.com/llm-evaluation)
 covers the concepts behind this page — offline versus online evaluation, when a deterministic check
 beats a judge, why the evaluation *level* decides what you can catch, and how to calibrate a judge
 before you let it gate a release.

--- a/docs/pages/mcp.mdx
+++ b/docs/pages/mcp.mdx
@@ -13,7 +13,7 @@ an evaluation column — without you leaving the editor or writing a line of API
 ## Connect
 
 ```bash
-claude mcp add --transport http tracely https://api.tracely-studio.xyz/mcp \
+claude mcp add --transport http tracely https://api.tracely-ai.com/mcp \
   --header "Authorization: Bearer $TRACELY_KEY"
 ```
 
@@ -26,7 +26,7 @@ Any MCP client works. The generic config, for the ones that take JSON:
   "mcpServers": {
     "tracely": {
       "type": "http",
-      "url": "https://api.tracely-studio.xyz/mcp",
+      "url": "https://api.tracely-ai.com/mcp",
       "headers": { "Authorization": "Bearer ${TRACELY_KEY}" }
     }
   }

--- a/docs/pages/replay.mdx
+++ b/docs/pages/replay.mdx
@@ -79,10 +79,10 @@ language, with no agent code in CI — see [Scenarios](/scenarios). Most teams r
 
 Next: the [CI gate CLI](/cli).
 
-Comparing tools? [Langfuse alternatives, compared honestly](https://tracely-studio.xyz/langfuse-alternatives)
+Comparing tools? [Langfuse alternatives, compared honestly](https://tracely-ai.com/langfuse-alternatives)
 covers how hermetic replay differs from dataset-and-live-calls CI, including where the other
 approach wins.
 
-Comparing tools? [Langfuse alternatives, compared honestly](https://tracely-studio.xyz/langfuse-alternatives)
+Comparing tools? [Langfuse alternatives, compared honestly](https://tracely-ai.com/langfuse-alternatives)
 covers how hermetic replay differs from dataset-and-live-calls CI, including where the other
 approach wins.

--- a/docs/pages/self-hosting.mdx
+++ b/docs/pages/self-hosting.mdx
@@ -8,7 +8,7 @@ import { Callout, Steps } from "nextra/components";
 
 Tracely is MIT-licensed and self-hosts completely — the same code that runs the hosted cloud.
 Two paths: **one-click Railway**, or **docker compose** on a box you own.
-(Or skip all of it: [tracely-studio.xyz](https://tracely-studio.xyz) has a free plan.)
+(Or skip all of it: [tracely-ai.com](https://tracely-ai.com) has a free plan.)
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/n5n_LE?referralCode=WCq5Cn&utm_medium=integration&utm_source=template&utm_campaign=generic)
 

--- a/docs/pages/skill.mdx
+++ b/docs/pages/skill.mdx
@@ -42,4 +42,4 @@ answer the question it was set up for.
   it."*
 </Callout>
 
-More on the [Tracely site](https://tracely-studio.xyz/agent-skill).
+More on the [Tracely site](https://tracely-ai.com/agent-skill).

--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -118,7 +118,7 @@ body::before {
   color: var(--fg);
 }
 
-/* "Product ↗" — the way back to tracely-studio.xyz from any docs page */
+/* "Product ↗" — the way back to tracely-ai.com from any docs page */
 .nextra-nav-container nav a.tracely-site-link {
   font-size: 13px;
   white-space: nowrap;

--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -2,8 +2,8 @@ import { useRouter } from "next/router";
 import { useConfig } from "nextra-theme-docs";
 
 const REPO = "https://github.com/Jwuthri/Tracely";
-const SITE = "https://tracely-studio.xyz";
-const DOCS = "https://doc.tracely-studio.xyz";
+const SITE = "https://tracely-ai.com";
+const DOCS = "https://doc.tracely-ai.com";
 
 // The app's sidebar mark (frontend/app/components/Sidebar.tsx), reused so docs and product share a face.
 const Logo = () => (
@@ -47,7 +47,7 @@ const config = {
     content: (
       <span style={{ fontSize: 13 }}>
         {/* Links back to the marketing origin on every page: docs pages are the ones that earn
-            inbound links, and this is how that authority reaches tracely-studio.xyz. */}
+            inbound links, and this is how that authority reaches tracely-ai.com. */}
         <a href={SITE}>Tracely</a> — trace-native CI/CD for AI agents · the recorded run{" "}
         <em>is</em> the test.
       </span>

--- a/frontend/app/(app)/settings/billing/page.tsx
+++ b/frontend/app/(app)/settings/billing/page.tsx
@@ -53,8 +53,8 @@ export default async function BillingPage() {
           <p className="px-4 py-4 text-[13.5px] leading-relaxed text-fg-muted">
             This deployment has no trace limits and no billing — every feature is yours already.
             The hosted cloud at{" "}
-            <a href="https://tracely-studio.xyz" className="text-signal hover:underline">
-              tracely-studio.xyz
+            <a href="https://tracely-ai.com" className="text-signal hover:underline">
+              tracely-ai.com
             </a>{" "}
             runs the same code with a free plan and managed infrastructure.
           </p>

--- a/frontend/app/(marketing)/Landing.tsx
+++ b/frontend/app/(marketing)/Landing.tsx
@@ -12,10 +12,10 @@ gsap.registerPlugin(useGSAP, ScrollTrigger);
 
 const GITHUB = "https://github.com/Jwuthri/Tracely";
 const APP = "/dashboard"; // same app — the authed shell lives in the (app) route group
-const DOCS = "https://doc.tracely-studio.xyz";
+const DOCS = "https://doc.tracely-ai.com";
 const LINKEDIN = "https://www.linkedin.com/in/julien-wuthrich-a75156119/";
 const INSTALL = 'pip install "tracely-ai[openai]"';
-const API = "https://api.tracely-studio.xyz"; // the hosted backend — self-hosters swap in their own
+const API = "https://api.tracely-ai.com"; // the hosted backend — self-hosters swap in their own
 
 /* ---------------------------------- ui bits ---------------------------------- */
 

--- a/frontend/app/(marketing)/agent-skill/page.tsx
+++ b/frontend/app/(marketing)/agent-skill/page.tsx
@@ -232,7 +232,7 @@ export default function Page() {
           both, once
         </div>
         <pre className="overflow-x-auto p-5 font-mono text-[12.5px] leading-[1.75] text-signal-soft">
-          {`${INSTALL}\nclaude mcp add --transport http tracely https://api.tracely-studio.xyz/mcp \\\n  --header "Authorization: Bearer $TRACELY_KEY"`}
+          {`${INSTALL}\nclaude mcp add --transport http tracely https://api.tracely-ai.com/mcp \\\n  --header "Authorization: Bearer $TRACELY_KEY"`}
         </pre>
       </div>
       <p className={prose.p}>

--- a/frontend/app/lib/site.ts
+++ b/frontend/app/lib/site.ts
@@ -1,7 +1,7 @@
 // The public origin, in one place: metadataBase, the sitemap, robots.txt and the JSON-LD all read
 // it, and a wrong value there silently breaks every absolute URL Google and Slack resolve.
-export const SITE_URL = "https://tracely-studio.xyz";
-export const DOCS_URL = "https://doc.tracely-studio.xyz";
+export const SITE_URL = "https://tracely-ai.com";
+export const DOCS_URL = "https://doc.tracely-ai.com";
 export const GITHUB_URL = "https://github.com/Jwuthri/Tracely";
 
 /** The homepage's search-facing title. Leads with what people type, not with the positioning line. */

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,23 @@
 /** @type {import('next').NextConfig} */
 // NOTE: do NOT add an `env: {...}` block here. Next inlines `env` values into the *client* bundle, so
 // TRACELY_KEY/TRACELY_API would leak to the browser. Server code reads them via process.env directly.
-const nextConfig = {};
+
+// The old .xyz domain stays attached to this same service so its backlinks keep resolving; every hit
+// on it is 308'd (method-preserving 301) to the same path on tracely-ai.com, which is what passes the
+// link equity on. `redirects()` runs BEFORE middleware in Next's routing order, so these never reach
+// the auth wall. Keep `tracely-studio.xyz` renewing for as long as those backlinks matter.
+// ponytail: a config redirect on the service that already owns the hostname — no proxy service.
+const OLD_HOSTS = ["tracely-studio.xyz", "www.tracely-studio.xyz", "www.tracely-ai.com"];
+
+const nextConfig = {
+  async redirects() {
+    return OLD_HOSTS.map((host) => ({
+      source: "/:path*",
+      has: [{ type: "host", value: host }],
+      destination: "https://tracely-ai.com/:path*",
+      permanent: true,
+    }));
+  },
+};
 
 export default nextConfig;

--- a/guides/DEPLOY.md
+++ b/guides/DEPLOY.md
@@ -17,6 +17,10 @@ works on any host running the same two containers.
 > [`.env.railway.example`](../deploy/railway/.env.railway.example). Either way, come back here to
 > harden it for production.
 
+> **Moving the site to a new domain?** The `tracely-studio.xyz` → `tracely-ai.com` move is
+> written up as a reusable runbook in [`guides/DOMAIN_MIGRATION.md`](DOMAIN_MIGRATION.md) —
+> hostname map, the 308 redirect that keeps the old backlinks alive, and the env vars to flip.
+
 ---
 
 ## 1. The prod refuse-to-boot guards

--- a/guides/DOMAIN_MIGRATION.md
+++ b/guides/DOMAIN_MIGRATION.md
@@ -1,0 +1,112 @@
+# Domain migration — `tracely-studio.xyz` → `tracely-ai.com`
+
+**Date:** 2026-08-22 · **Reason:** `.xyz` ranks poorly; `tracely-ai.com` matches the PyPI package
+name (`tracely-ai`) and is the domain we want to accrue authority on.
+
+The old domain is **not** retired. It stays registered, stays attached to the same Railway services,
+and 308-redirects every path to the new one — that redirect is the only thing that carries the
+existing backlinks' authority across. Detaching it would throw them away.
+
+---
+
+## 1. Hostname map
+
+| Old | New | Railway service | Port | Behaviour on the old host |
+|---|---|---|---|---|
+| `tracely-studio.xyz` | `tracely-ai.com` | `frontend` | 8080 | 308 → same path on the new host |
+| — | `www.tracely-ai.com` | `frontend` | 8080 | 308 → apex (`tracely-ai.com`) |
+| `doc.tracely-studio.xyz` | `doc.tracely-ai.com` | `Doc` | 8080 | 308 → same path on the new host |
+| `api.tracely-studio.xyz` | `api.tracely-ai.com` | `api` | 8000 | **serves normally — no redirect** |
+
+The API host is deliberately *not* redirected. SDKs, OTLP exporters and the MCP client post to it,
+and not every HTTP client follows a redirect on a POST. Both hostnames point at the same service and
+both stay live indefinitely; there is no SEO reason to move an API host.
+
+`tracely-ai.com` was bought through Railway, so Railway's registrar (name.com) created the CNAME /
+apex-ALIAS records automatically when each domain was attached. Nothing to configure by hand.
+
+## 2. The redirect
+
+No proxy service, no extra deploy target: the old hostnames are still attached to the services that
+already serve them, and each Next app 308s anything arriving on an old host.
+
+- [`frontend/next.config.mjs`](../frontend/next.config.mjs) — `OLD_HOSTS` → `https://tracely-ai.com/:path*`
+- [`docs/next.config.mjs`](../docs/next.config.mjs) — `doc.tracely-studio.xyz` → `https://doc.tracely-ai.com/:path*`
+
+Two things make this work and are easy to break:
+
+1. **`redirects()` runs before middleware** in Next's routing order, so a dashboard URL on the old
+   host is redirected instead of being bounced to `/login` by the auth guard first.
+2. **308, not 302** (`permanent: true`). Google treats 308 like 301 and passes link equity; a 302
+   passes none. 308 also preserves the request method, unlike 301.
+
+Session cookies are host-scoped, so anyone who was signed in on `tracely-studio.xyz` lands on the
+new domain signed out and logs in once. Expected, not a bug.
+
+## 3. Railway state
+
+Custom domains added (production environment, project `tracely`):
+
+```
+frontend  a57c06c3-…  tracely-ai.com:8080, www.tracely-ai.com:8080   (+ tracely-studio.xyz:8080 kept)
+api       c239e89a-…  api.tracely-ai.com:8000                        (+ api.tracely-studio.xyz:8000 kept)
+Doc       03008626-…  doc.tracely-ai.com:8080                        (+ doc.tracely-studio.xyz:8080 kept)
+```
+
+Variables changed:
+
+| Service | Variable | New value |
+|---|---|---|
+| `api` | `APP_BASE_URL` | `https://tracely-ai.com` — invite / reset-password / alert / Stripe-return links |
+| `api` | `FRONTEND_ORIGIN` | `https://tracely-ai.com` — the single CORS allow-origin (`api/main.py`) |
+| `frontend` | `NEXT_PUBLIC_API_URL` | `https://api.tracely-ai.com` |
+| `frontend` | `NEXT_PUBLIC_TRACELY_PUBLIC_API` | `https://api.tracely-ai.com` |
+
+`TRACELY_API` stays `http://api.railway.internal:8000` — server-side calls never leave the private
+network. `CORS_ORIGINS` exists on both services but is read by nothing in the repo; it is dead.
+
+## 4. Code changed
+
+Every occurrence of the old domain in the repo was rewritten. Notable ones:
+
+| File | What |
+|---|---|
+| `frontend/app/lib/site.ts` | `SITE_URL` / `DOCS_URL` — feeds `metadataBase`, `sitemap.ts`, `robots.ts`, JSON-LD |
+| `frontend/app/(marketing)/Landing.tsx` | `DOCS`, `API` constants shown in the copy-paste snippets |
+| `frontend/app/(marketing)/agent-skill/page.tsx` | the `claude mcp add` command |
+| `frontend/app/(app)/settings/billing/page.tsx` | hosted-plan link |
+| `docs/theme.config.jsx` | `SITE` / `DOCS` — docs canonical + OG tags + the "Product ↗" pill |
+| `docs/pages/*.mdx` | MCP endpoint, hosted API host, cross-links to marketing pages |
+| `skills/tracely/**` | the agent skill's hosted endpoint + docs links |
+| `sdk/pyproject.toml` | `Homepage` / `Documentation` (PyPI sidebar) |
+| `server.json` | MCP registry entry: `websiteUrl` + the remote `/mcp` URL |
+| `README.md`, `design/SEO.md`, `design/GROWTH.md` | all links |
+
+## 5. Manual follow-ups (need accounts I don't have)
+
+- [ ] **Turn auto-renew ON for `tracely-studio.xyz`** (Railway → Domains). It expires **2027-07-27**
+      with auto-renew off. The day it lapses, every inbound backlink 404s and the migration's whole
+      point is lost. Keep it for at least a year after the move.
+- [ ] **Google Search Console** — add `tracely-ai.com` as a property, verify it, then run
+      *Settings → Change of address* from the `tracely-studio.xyz` property. That is the signal that
+      makes Google transfer rankings quickly instead of re-discovering the site. Requires both
+      properties verified and the 308 live. Resubmit `https://tracely-ai.com/sitemap.xml`.
+- [ ] **Resend** — `EMAIL_FROM` is still `invites@tracely-studio.xyz`. Verify `tracely-ai.com` at
+      resend.com/domains (DNS records go in Railway's DNS for the domain), then set
+      `EMAIL_FROM="Tracely <invites@tracely-ai.com>"` on the `api` service. It works as-is until then.
+- [ ] **PyPI** — the new `Homepage`/`Documentation` only appear after the next `tracely-ai` release.
+- [ ] **MCP registry** — republish `server.json` so the listed remote URL is the new one.
+- [ ] **The 2–3 existing backlinks** — the 308 is enough for SEO, but ask the linking sites to point
+      at `tracely-ai.com` directly where it's cheap. A direct link is worth more than a redirected one.
+- [ ] **Anywhere off-repo the old URL is pasted** — GitHub repo homepage field, PyPI project page,
+      LinkedIn, Product Hunt, X bio, any launch posts.
+
+## 6. Verify
+
+```bash
+curl -sI https://tracely-studio.xyz/llm-evaluation | head -3        # 308 → https://tracely-ai.com/llm-evaluation
+curl -sI https://doc.tracely-studio.xyz/mcp | head -3               # 308 → https://doc.tracely-ai.com/mcp
+curl -s https://tracely-ai.com/robots.txt                           # sitemap + host must say tracely-ai.com
+curl -s https://api.tracely-ai.com/health                           # 200, no redirect
+curl -s https://api.tracely-studio.xyz/health                       # 200, still no redirect
+```

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://tracely-studio.xyz"
-Documentation = "https://doc.tracely-studio.xyz"
+Homepage = "https://tracely-ai.com"
+Documentation = "https://doc.tracely-ai.com"
 Source = "https://github.com/Jwuthri/Tracely"
 Issues = "https://github.com/Jwuthri/Tracely/issues"
 

--- a/server.json
+++ b/server.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/Jwuthri/Tracely",
     "source": "github"
   },
-  "websiteUrl": "https://tracely-studio.xyz",
+  "websiteUrl": "https://tracely-ai.com",
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://api.tracely-studio.xyz/mcp"
+      "url": "https://api.tracely-ai.com/mcp"
     }
   ]
 }

--- a/skills/tracely/SKILL.md
+++ b/skills/tracely/SKILL.md
@@ -13,7 +13,7 @@ production trace → failure detection → regression test → CI gate
 ```
 
 The trace is the source of truth. Evaluators, failure clusters, regression cases, gates and trends
-are all **derived from it** — there are no hand-authored datasets. Docs: <https://doc.tracely-studio.xyz>.
+are all **derived from it** — there are no hand-authored datasets. Docs: <https://doc.tracely-ai.com>.
 
 ## Pick the path first
 
@@ -38,7 +38,7 @@ compose — manual spans nest inside auto-instrumented traces in the same tree.
 import tracely_sdk as tracely   # pip install "tracely-ai[openai]"  ([anthropic] [langchain] [all])
 
 tracely.init(
-    endpoint="http://localhost:8000",   # hosted: https://api.tracely-studio.xyz
+    endpoint="http://localhost:8000",   # hosted: https://api.tracely-ai.com
     api_key="tracely_dev_key",          # an ingest key — Settings → API keys. The key IS the workspace.
     service_name="support-agent",
     env="prod",                         # prod | staging | ci | dev — the gating axis
@@ -167,7 +167,7 @@ runs and hermetic replay: **`references/ci-gate.md`**.
 Every backend serves MCP at `/mcp` — read traces, inspect clusters, create evaluators, no glue code.
 
 ```bash
-claude mcp add --transport http tracely https://api.tracely-studio.xyz/mcp \
+claude mcp add --transport http tracely https://api.tracely-ai.com/mcp \
   --header "Authorization: Bearer $TRACELY_KEY"
 ```
 
@@ -198,4 +198,4 @@ suspiciously green: **`references/troubleshooting.md`** — symptom → cause �
 | `references/troubleshooting.md` | Something isn't showing up or the gate is lying. |
 
 Self-hosting (`docker compose up -d --build --wait` → UI :3001, API :8000, dev key
-`tracely_dev_key`) and Railway one-click: <https://doc.tracely-studio.xyz/self-hosting>.
+`tracely_dev_key`) and Railway one-click: <https://doc.tracely-ai.com/self-hosting>.

--- a/skills/tracely/references/automatic.md
+++ b/skills/tracely/references/automatic.md
@@ -244,7 +244,7 @@ conversation:
 Everything else is inferred. Failures need no special handling: an ERROR span status, a recorded
 `exception` event, or an `error.type` attribute all mark the span failed.
 
-The full indexed-attribute list is in the API reference: <https://doc.tracely-studio.xyz/api-reference>.
+The full indexed-attribute list is in the API reference: <https://doc.tracely-ai.com/api-reference>.
 
 ## Runnable examples
 

--- a/skills/tracely/references/troubleshooting.md
+++ b/skills/tracely/references/troubleshooting.md
@@ -7,7 +7,7 @@ Work top-down: most "Tracely is broken" reports are one of the first four rows.
 | Symptom | Cause | Fix |
 |---|---|---|
 | No trace at all after a script run | Process exited before the exporter flushed | `tracely.flush()` before exit — always in scripts, tests, Lambdas, CLI runs |
-| No trace, no error | Wrong `endpoint` — it must be the **API** host, not the UI | `http://localhost:8000` (API), not `:3001` (UI). Hosted: `https://api.tracely-studio.xyz` |
+| No trace, no error | Wrong `endpoint` — it must be the **API** host, not the UI | `http://localhost:8000` (API), not `:3001` (UI). Hosted: `https://api.tracely-ai.com` |
 | `401` / traces vanish | Wrong or missing ingest key | The key **is** the workspace: Settings → API keys. Self-host dev seed is `tracely_dev_key` |
 | Traces appear seconds late | Normal — evaluation is debounced ~4s to absorb late spans | Wait, then refresh |
 | Spans arrive, nothing renders | Hand-written OTLP with **hex** span ids | OTLP span ids are **base64**. Hex doesn't error, it yields a 24-byte id nothing can look up. Use a real OTLP exporter |


### PR DESCRIPTION
Moves the public site from `tracely-studio.xyz` to `tracely-ai.com`.

**Already done on Railway** (live now): `tracely-ai.com` + `www` → `frontend`, `api.tracely-ai.com` → `api`, `doc.tracely-ai.com` → `Doc`, all with certs issued. `APP_BASE_URL` / `FRONTEND_ORIGIN` / `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_TRACELY_PUBLIC_API` flipped.

**What merging adds:** the 308 redirects from the old hostnames (they stay attached to the same services, so their backlinks keep resolving and pass authority), plus every doc/README/skill/PyPI/MCP-registry URL rewritten.

`api.tracely-studio.xyz` is deliberately *not* redirected — SDKs and OTLP exporters POST to it.

Runbook and the manual follow-ups that need account access (Search Console change of address, Resend domain, PyPI release, `.xyz` auto-renew) are in [`guides/DOMAIN_MIGRATION.md`](guides/DOMAIN_MIGRATION.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)