### PR TITLE
Remove duplicated comparison link in hermetic replay documentation

### DIFF
--- a/docs/pages/replay.mdx
+++ b/docs/pages/replay.mdx
@@ -83,6 +83,3 @@ Comparing tools? [Langfuse alternatives, compared honestly](https://tracely-ai.c
 covers how hermetic replay differs from dataset-and-live-calls CI, including where the other
 approach wins.
 
-Comparing tools? [Langfuse alternatives, compared honestly](https://tracely-ai.com/langfuse-alternatives)
-covers how hermetic replay differs from dataset-and-live-calls CI, including where the other
-approach wins.


### PR DESCRIPTION
The "Comparing tools? Langfuse alternatives, compared honestly" paragraph at the bottom of `docs/pages/replay.mdx` was accidentally duplicated. This change removes the redundant second copy.