### PR TITLE
Map OpenInference's first-token span event to completion_start_time

### DIFF
--- a/backend/tests/test_otel_mapping.py
+++ b/backend/tests/test_otel_mapping.py
@@ -87,25 +87,35 @@ def test_to_rows_shape() -> None:
 
 
 def _event(
-    attrs: dict, *, status_code: int = 0, name: str = "span", events: list | None = None
+    attrs: dict,
+    *,
+    status_code: int = 0,
+    name: str = "span",
+    events: list | None = None,
+    times: tuple[int, int, int] = (1_000, 2_000, 1_500),
 ) -> dict:
     """Build one span from a flat {key: value} attr dict and return its mapped event.
 
     `events` is a list of `(event_name, {attr: value})` — span events, which carry both recorded
     exceptions and the OTel GenAI *event* message convention.
+
+    `times` is `(span start, span end, event)` in epoch nanoseconds. The default is a toy window;
+    anything that asserts on a *duration* must pass real nanos, since a datetime only has
+    microsecond resolution and the default 500ns gap rounds away.
     """
+    start_ns, end_ns, event_ns = times
     span = Span(
         name=name,
         trace_id=b"\x01" * 16,
         span_id=b"\x02" * 8,
-        start_time_unix_nano=1_000,
-        end_time_unix_nano=2_000,
+        start_time_unix_nano=start_ns,
+        end_time_unix_nano=end_ns,
     )
     span.attributes.extend([_kv(k, v) for k, v in attrs.items()])
     for ev_name, ev_attrs in events or []:
         ev = span.events.add()
         ev.name = ev_name
-        ev.time_unix_nano = 1_500
+        ev.time_unix_nano = event_ns
         ev.attributes.extend([_kv(k, v) for k, v in ev_attrs.items()])
     if status_code:
         span.status.code = status_code
@@ -401,6 +411,46 @@ def test_genai_event_convention_messages_are_read():
     )
     assert json.loads(e["input"])[0] == {"role": "user", "content": "what is 2+2?"}
     assert json.loads(e["output"])[0]["content"] == "4"
+
+
+# span 1.0s → 3.0s, first chunk at 1.5s: a 500ms TTFT.
+_STREAMED = (1_000_000_000, 3_000_000_000, 1_500_000_000)
+
+
+def test_openinference_first_token_event_becomes_completion_start_time():
+    """The default `init(instrument=[...])` path marks the first streamed chunk with a span EVENT,
+    not an attribute — so streamed spans arrived with a NULL `completion_start_time` and the ops
+    TTFT metric had nothing to read for anyone who wasn't on the drop-in wrappers."""
+    e = _event(
+        {"openinference.span.kind": "LLM", "llm.model_name": "gpt-4o"},
+        events=[("First Token Stream Event", {})],
+        times=_STREAMED,
+    )
+    assert (e["completion_start_time"] - e["start_time"]).total_seconds() == 0.5
+
+
+def test_our_own_completion_start_attribute_wins_over_the_event():
+    """The drop-in wrappers stamp the first CONTENT delta — a sharper mark than the instrumentors'
+    first-chunk-of-any-kind, and the one the thinking/generation split reads."""
+    e = _event(
+        {"openinference.span.kind": "LLM", "tracely.completion_start_time": 2_000_000_000},
+        events=[("First Token Stream Event", {})],
+        times=_STREAMED,
+    )
+    assert (e["completion_start_time"] - e["start_time"]).total_seconds() == 1.0
+
+
+def test_an_unrelated_span_event_is_not_a_first_token_mark():
+    e = _event(
+        {"openinference.span.kind": "LLM"},
+        events=[("exception", {"exception.type": "ValueError"})],
+        times=_STREAMED,
+    )
+    assert e["completion_start_time"] is None
+
+
+def test_a_non_streamed_span_has_no_completion_start_time():
+    assert _event({"openinference.span.kind": "LLM"})["completion_start_time"] is None
 
 
 def test_attributes_win_over_events():

--- a/backend/tracely/otel/span_events.py
+++ b/backend/tracely/otel/span_events.py
@@ -1,6 +1,6 @@
 """Span *events* — the half of OTLP the attribute mappers can't see.
 
-Two things ride on events rather than attributes, and both were being dropped:
+Three things ride on events rather than attributes, and all were being dropped:
 
 1. **Exceptions.** `span.record_exception()` writes an `exception` event with the type, message
    and stacktrace. Plenty of instrumentors record one WITHOUT also setting the span status to
@@ -12,14 +12,20 @@ Two things ride on events rather than attributes, and both were being dropped:
    (which the Tracely SDK itself activates as a fallback) emits prompts and completions as
    `gen_ai.user.message` / `gen_ai.choice` events instead of attributes, so those spans arrived
    with a model and a token count but no conversation at all.
+
+3. **Time to first token.** The OpenInference instrumentors — the default `init(instrument=[...])`
+   path — mark the first streamed chunk with a `First Token Stream Event` span event rather than an
+   attribute, so `completion_start_time` (attribute-only until now) was always NULL on that path and
+   the ops TTFT metric had nothing to read. See `first_token_time`.
 """
 
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from typing import Any
 
-from tracely.otel.attributes import _attrs
+from tracely.otel.attributes import _attrs, _ns_to_dt
 
 # Event name → the role the message carries. `gen_ai.choice` is the model's reply.
 _ROLE_EVENTS = {
@@ -29,6 +35,10 @@ _ROLE_EVENTS = {
     "gen_ai.tool.message": "tool",
 }
 _CHOICE_EVENT = "gen_ai.choice"
+
+# OpenInference's first-streamed-chunk marker. Named, not versioned — same string across their
+# openai / mistralai / llama-index instrumentors.
+_FIRST_TOKEN_EVENT = "First Token Stream Event"
 
 # Where an event puts its payload, in order. Emitters disagree: the stable semconv uses the
 # `content`/`role` attribute pair, the 0.4x-era one packed a JSON body under `gen_ai.event.content`.
@@ -55,6 +65,26 @@ def exception_text(span: Any) -> str:
         if etype or emsg:
             return etype or emsg
     return ""
+
+
+def first_token_time(span: Any) -> datetime | None:
+    """When the first streamed chunk arrived, from the instrumentors' own first-token span event.
+
+    OpenInference's stream proxies (`openai`, `mistralai`, `llama_index`) call
+    `span.add_event("First Token Stream Event")` on the first chunk — this maps that existing signal
+    instead of instrumenting the default path ourselves. Note it fires on the first chunk of ANY
+    kind, so unlike the drop-in wrappers' `tracely.completion_start_time` (first CONTENT delta, which
+    doubles as the thinking→answering boundary) it is plain TTFT: for a reasoning model it lands at
+    the start of the thinking, not after it.
+
+    The other instrumentors (anthropic, langchain, google-genai, groq, bedrock) emit no such event,
+    so their streamed spans still have no TTFT — they do, however, already hold the span open until
+    the stream is exhausted, so nothing is lost beyond this one mark.
+    """
+    for event in getattr(span, "events", None) or ():
+        if getattr(event, "name", "") == _FIRST_TOKEN_EVENT:
+            return _ns_to_dt(getattr(event, "time_unix_nano", 0) or 0)
+    return None
 
 
 def _payload(a: dict[str, Any]) -> Any:

--- a/backend/tracely/otel/span_mapper.py
+++ b/backend/tracely/otel/span_mapper.py
@@ -18,7 +18,7 @@ from tracely.otel.io_field import (
 )
 from tracely.otel.attributes import _to_str as _stringify
 from tracely.otel.messages import _as_obj, _normalize_parsed
-from tracely.otel.span_events import events_io, exception_text
+from tracely.otel.span_events import events_io, exception_text, first_token_time
 from tracely.otel.tool_enrichment import _tool_call_names
 from tracely.otel.types import EMBEDDING, GENERATION, TOOL, map_observation_type
 from tracely.otel.usage import (
@@ -102,7 +102,9 @@ def _map_span(
         "parent_span_id": parent_span_id,
         "start_time": _ns_to_dt(span.start_time_unix_nano),
         "end_time": _ns_to_dt(span.end_time_unix_nano),
-        "completion_start_time": _completion_start(a),
+        # Our own attribute (the drop-in wrappers) first; the OpenInference instrumentors' own
+        # first-token span *event* is the fallback that gives the default path a TTFT at all.
+        "completion_start_time": _completion_start(a) or first_token_time(span),
         # For TOOL spans, prefer the actual tool name from attrs over the framework's generic
         # span name (LlamaIndex uses `FunctionTool.acall`, etc.) — so the UI shows the tool
         # name and the tool_consistency eval can match "requested" against "executed".


### PR DESCRIPTION
TTFT was only ever recorded on the drop-in wrapper path (`tracely_sdk.openai` and friends), which stamps a `tracely.completion_start_time` attribute. The default onboarding path — `init(instrument=[...])`, the OpenInference instrumentors — got nothing, so streamed generations landed with `completion_start_time = NULL` and the ops TTFT metric had no data for most users.

The instrumentors already emit the signal, just as a span **event** rather than an attribute: `span.add_event("First Token Stream Event")` on the first streamed chunk (their `openai`, `mistralai` and `llama_index` packages). `otel/span_events.py` already exists to read the half of OTLP the attribute mappers can't see — recorded exceptions and GenAI-convention messages — so this adds `first_token_time(span)` there and uses it as the fallback in `span_mapper`. Our own attribute still wins when present.

**No new instrumentation was added**, and none was needed for the other half of the concern: the OpenInference instrumentors proxy the stream object and end the span at exhaustion, so the "streamed span closes before any token" bug the wrappers had does not exist on this path.

Two limits, documented in the code rather than worked around:
- The event fires on the first chunk of *any* kind, so this is plain TTFT — not the thinking→answering boundary the wrappers' first-CONTENT-delta mark provides. Matching that would mean reimplementing each instrumentor's stream proxy.
- The anthropic, langchain, google-genai, groq and bedrock instrumentors emit no first-token event, so those streamed spans still have no TTFT.

Tests: four cases in `test_otel_mapping.py` covering the event mapping, attribute precedence, an unrelated event, and a non-streamed span. The `_event` helper's span/event timestamps are now a parameter — its default 500ns gap is below `datetime`'s microsecond resolution, so duration assertions need real nanos. These were not executed; test and lint commands were unavailable in the authoring environment.

Closes #50