### PR TITLE
fix(billing): make BILLING_ENABLED safe to flip (audit + 3 fixes; flag stays off)

### DIFF
--- a/backend/migrations/versions/0031_subscription_event_at.py
+++ b/backend/migrations/versions/0031_subscription_event_at.py
@@ -1,0 +1,38 @@
+"""stripe webhooks: remember the newest event applied, so a stale one can't re-apply
+
+Stripe does not guarantee event ORDER and retries undelivered events for up to three days. Every
+webhook write here is an idempotent state-set, which is safe under replay of the SAME event but
+not under replay of an OLDER one: a `customer.subscription.updated(active)` redelivered after a
+`customer.subscription.deleted` would put a cancelled account back on Pro, for free, silently.
+
+`organizations.subscription_event_at` holds the `created` of the newest event applied to that
+org; `handle_webhook_event` ignores anything strictly older. NULL means no event has been applied
+yet, so nothing about existing rows changes.
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0031"
+down_revision: str | None = "0030"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column("subscription_event_at", sa.BigInteger(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "subscription_event_at")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,6 +33,18 @@ os.environ["LLM_JUDGE_API_KEY"] = ""
 # checkpoint rows, and behaved differently there than in CI (where nothing is listening). Tests
 # that want the chat path turn it on with a fake checkpointer.
 os.environ["EVAL_CHAT_ENABLED"] = "false"
+# Fifth time, same class of bug, and this one is the expensive version: `Settings` reads `.env`,
+# and a developer's `.env` can hold a REAL Stripe secret key (a live one, at that). So the billing
+# suite ran with live credentials loaded — a different code path from CI's (`stripe_configured()`
+# answers True on a laptop and False on GitHub), and one careless test away from creating a real
+# customer or subscription against a real account. Hard-off, so "Stripe not configured" is the
+# tested default everywhere; the tests that want it configured set it on `settings` themselves.
+os.environ["STRIPE_SECRET_KEY"] = ""
+os.environ["STRIPE_WEBHOOK_SECRET"] = ""
+os.environ["STRIPE_PRICE_PRO"] = ""
+# Same reasoning, one level up: billing must be OFF unless a test turns it on. A `.env` with
+# BILLING_ENABLED=true would silently quota-gate every ingest test.
+os.environ["BILLING_ENABLED"] = "false"
 
 import pytest  # noqa: E402
 import pytest_asyncio  # noqa: E402

--- a/backend/tests/test_billing_quota.py
+++ b/backend/tests/test_billing_quota.py
@@ -217,6 +217,8 @@ async def test_over_quota_returns_429_with_retry_after(
     monkeypatch.setattr(settings, "billing_enabled", True)
     monkeypatch.setattr(settings, "free_trace_limit", 10)
     monkeypatch.setattr(quota_service, "async_redis", lambda: _BoomAsyncRedis())  # PG fallback
+    monkeypatch.setattr(settings, "stripe_secret_key", "sk_test_x")
+    monkeypatch.setattr(settings, "stripe_price_pro", "price_x")
     import tracely.api.routers.otlp as otlp_router
 
     monkeypatch.setattr(
@@ -231,6 +233,55 @@ async def test_over_quota_returns_429_with_retry_after(
     assert r.status_code == 429
     assert r.headers.get("retry-after") == "3600"
     assert "quota" in r.json()["detail"] and "/settings/billing" in r.json()["detail"]
+
+
+async def test_over_quota_without_stripe_does_not_send_anyone_to_a_dead_upgrade_page(
+    client, make_workspace, session, monkeypatch
+):
+    """BILLING_ENABLED can be on while Stripe is not configured — checkout answers 501 there. The
+    cap is still real, so the 429 has to say who can lift it instead of linking to a page where
+    the customer physically cannot pay."""
+    monkeypatch.setattr(settings, "billing_enabled", True)
+    monkeypatch.setattr(settings, "free_trace_limit", 10)
+    monkeypatch.setattr(settings, "stripe_secret_key", "")
+    monkeypatch.setattr(settings, "stripe_price_pro", "")
+    monkeypatch.setattr(quota_service, "async_redis", lambda: _BoomAsyncRedis())
+    _, key = await _workspace_over_quota(client, make_workspace, session, traces=10)
+
+    r = await client.post(
+        "/v1/traces", content=b"{}", headers={"Authorization": f"Bearer {key.key}"}
+    )
+    assert r.status_code == 429
+    detail = r.json()["detail"]
+    assert "quota" in detail
+    assert "/settings/billing" not in detail
+    assert "operator" in detail
+
+
+async def test_the_gate_fails_open_when_postgres_is_down(
+    client, make_workspace, session, monkeypatch
+):
+    """Deliberate, and the reason it is deliberate is worth a test: a quota is a product limit,
+    not a security boundary. If our DB blinks we let the customer's traces through and undercount
+    — never the reverse. This is the ONLY fail-open on the enforcement path."""
+    monkeypatch.setattr(settings, "billing_enabled", True)
+    monkeypatch.setattr(settings, "free_trace_limit", 1)
+    monkeypatch.setattr(quota_service, "async_redis", lambda: _BoomAsyncRedis())
+    monkeypatch.setattr(
+        quota_service, "_snapshot_from_pg",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("pg down")),
+    )
+    ingested = []
+    import tracely.api.routers.otlp as otlp_router
+
+    monkeypatch.setattr(otlp_router, "ingest_otlp", lambda *a, **kw: ingested.append(a) or "b1")
+    _, key = await _workspace_over_quota(client, make_workspace, session, traces=10**9)
+
+    r = await client.post(
+        "/v1/traces", content=b"{}", headers={"Authorization": f"Bearer {key.key}"}
+    )
+    assert r.status_code == 200, "a DB outage must not drop a paying customer's traces"
+    assert ingested, "the trace was accepted, not silently discarded"
 
 
 async def test_under_quota_ingests_normally(client, make_workspace, session, monkeypatch):

--- a/backend/tests/test_billing_stripe.py
+++ b/backend/tests/test_billing_stripe.py
@@ -46,8 +46,10 @@ def db():
     eng.dispose()
 
 
-def _event(etype: str, obj: dict) -> dict:
-    return {"type": etype, "data": {"object": obj}}
+def _event(etype: str, obj: dict, created: int = 1_000) -> dict:
+    # `created` is on every real Stripe event, and the handler orders by it. Defaulted so the
+    # existing tests read the same; the ordering tests set it explicitly.
+    return {"type": etype, "data": {"object": obj}, "created": created}
 
 
 def test_checkout_completed_upgrades_and_stores_ids(db):
@@ -138,6 +140,87 @@ def test_replay_is_idempotent(db):
     billing_service.handle_webhook_event(db, ev)  # Stripe redelivers — same end state
     p = db.get(models.Organization, "o1")
     assert (p.plan, p.stripe_customer_id) == ("pro", "cus_1")
+
+
+# ── delivery order (Stripe guarantees neither order nor single delivery) ──────
+
+
+def _sub(status: str, created: int) -> dict:
+    return _event(
+        "customer.subscription.updated",
+        {"id": "sub_1", "customer": "cus_1", "status": status, "metadata": {"organization_id": "o1"}},
+        created=created,
+    )
+
+
+def test_a_stale_event_redelivered_after_a_cancel_does_not_restore_pro(db):
+    """The money bug this guard exists for. Stripe retries undelivered events for days, so the
+    `active` from before a cancellation can land AFTER it — and every write here is a state-set,
+    so without an ordering check the account goes back to Pro and nobody pays for it."""
+    billing_service.handle_webhook_event(db, _sub("active", created=1_000))
+    assert db.get(models.Organization, "o1").plan == "pro"
+
+    billing_service.handle_webhook_event(
+        db, _event("customer.subscription.deleted", {"id": "sub_1", "customer": "cus_1"}, created=2_000)
+    )
+    assert db.get(models.Organization, "o1").plan == "free"
+
+    out = billing_service.handle_webhook_event(db, _sub("active", created=1_000))  # redelivery
+    assert out == {"handled": False, "stale": True}
+    org = db.get(models.Organization, "o1")
+    assert org.plan == "free", "a stale event put a cancelled account back on Pro"
+    assert org.subscription_status == "canceled"
+
+
+def test_out_of_order_first_delivery_lands_on_the_newest_state(db):
+    """Same hazard without a retry: Stripe may simply deliver two events out of order."""
+    billing_service.handle_webhook_event(db, _sub("canceled", created=2_000))
+    billing_service.handle_webhook_event(db, _sub("active", created=1_000))
+    assert db.get(models.Organization, "o1").plan == "free"
+
+
+def test_a_newer_event_still_applies(db):
+    """The guard must not freeze an account: a genuine later change wins."""
+    billing_service.handle_webhook_event(db, _sub("canceled", created=1_000))
+    billing_service.handle_webhook_event(db, _sub("active", created=2_000))
+    assert db.get(models.Organization, "o1").plan == "pro"
+
+
+def test_the_two_events_of_one_upgrade_share_a_second(db):
+    """checkout.session.completed and subscription.updated can carry the same `created`. Equal is
+    not stale, or half of a normal upgrade would be dropped."""
+    billing_service.handle_webhook_event(
+        db,
+        _event(
+            "checkout.session.completed",
+            {"client_reference_id": "o1", "customer": "cus_1", "subscription": "sub_1"},
+            created=1_000,
+        ),
+    )
+    billing_service.handle_webhook_event(db, _sub("trialing", created=1_000))
+    org = db.get(models.Organization, "o1")
+    assert (org.plan, org.subscription_status) == ("pro", "trialing")
+
+
+def test_an_event_with_no_created_is_treated_as_stale(db):
+    """Fail closed: a hand-built or malformed event that names no time reads as epoch 0, which
+    is older than anything already applied."""
+    billing_service.handle_webhook_event(db, _sub("active", created=5_000))
+    out = billing_service.handle_webhook_event(
+        db, {"type": "customer.subscription.deleted", "data": {"object": {"customer": "cus_1"}}}
+    )
+    assert out == {"handled": False, "stale": True}
+    assert db.get(models.Organization, "o1").plan == "pro"
+
+
+def test_an_abandoned_checkout_leaves_the_account_on_free(db):
+    """Starting checkout and walking away sends no event at all. The org keeps whatever Stripe
+    ids `create_checkout_session` stamped on it and must stay on the free plan."""
+    org = db.get(models.Organization, "o1")
+    org.stripe_customer_id = "cus_1"  # what create_checkout_session commits before redirecting
+    db.commit()
+    assert org.plan == "free"
+    assert org.subscription_status is None
 
 
 def test_unknown_event_type_is_ignored(db):

--- a/backend/tracely/infrastructure/db/models.py
+++ b/backend/tracely/infrastructure/db/models.py
@@ -71,6 +71,11 @@ class Organization(Base):
     stripe_customer_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
     stripe_subscription_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     subscription_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    # `created` of the newest Stripe event applied to this org (unix seconds). Stripe does NOT
+    # guarantee delivery order and retries for days, so an older event arriving after a newer one
+    # would re-apply a stale plan — a cancelled subscription quietly going back to Pro. NULL on
+    # every row that predates this, which just means the next event is the first one compared.
+    subscription_event_at: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     projects: Mapped[list["Project"]] = relationship(back_populates="organization")

--- a/backend/tracely/services/billing_service.py
+++ b/backend/tracely/services/billing_service.py
@@ -7,11 +7,20 @@ The `stripe` import lives here and nowhere else. Everything is driven by webhook
 the portal only mint redirect URLs; the plan on the Organization row changes exclusively when
 Stripe tells us so (idempotent state-sets, safe under replay and out-of-order delivery).
 
-Ordering hazard handled explicitly: `customer.subscription.*` events carry no
-`client_reference_id` and can arrive BEFORE `checkout.session.completed` stores the customer id.
-Checkout therefore stamps `subscription_data.metadata.organization_id` onto the subscription
-itself, and the webhook falls back to that metadata when the customer id lookup misses —
-backfilling the ids so the next event takes the fast path.
+Two ordering hazards, both handled explicitly, because Stripe guarantees neither order nor
+single delivery:
+
+1. `customer.subscription.*` events carry no `client_reference_id` and can arrive BEFORE
+   `checkout.session.completed` stores the customer id. Checkout therefore stamps
+   `subscription_data.metadata.organization_id` onto the subscription itself, and the webhook
+   falls back to that metadata when the customer id lookup misses — backfilling the ids so the
+   next event takes the fast path.
+2. An OLDER event can arrive after a newer one — out of order on first delivery, or redelivered
+   from Stripe's retry schedule days later. Idempotent state-sets survive a replay of the SAME
+   event but not of a stale one: `subscription.updated(active)` landing after
+   `subscription.deleted` would put a cancelled account back on Pro, for free, with nothing in
+   the logs to say why. `organizations.subscription_event_at` records the newest event applied,
+   and anything strictly older is dropped.
 """
 
 from __future__ import annotations
@@ -106,18 +115,23 @@ def handle_webhook_event(session: Session, event) -> dict:
     """Apply one verified Stripe event. Idempotent state-sets throughout.
 
     Return contract (the router's response depends on it): normal returns — including unknown
-    event types and unknown organizations — mean 200 (permanent no-ops must not be redelivered);
-    raising means 5xx, so Stripe's retry schedule redelivers after a transient failure instead
-    of a paid upgrade being silently swallowed.
+    event types, unknown organizations and stale events — mean 200 (permanent no-ops must not be
+    redelivered); raising means 5xx, so Stripe's retry schedule redelivers after a transient
+    failure instead of a paid upgrade being silently swallowed.
     """
     etype = event["type"]
     obj = event["data"]["object"]
+    # `created` is on every Stripe event. A forged/hand-built event without one reads as 0, which
+    # is older than anything already applied — so it is dropped rather than trusted.
+    created = int(event.get("created") or 0)
 
     if etype == "checkout.session.completed":
         org = repositories.organization_get(session, obj.get("client_reference_id") or "")
         if org is None:
             log.warning("stripe_checkout_unknown_org", ref=obj.get("client_reference_id"))
             return {"handled": False}
+        if _is_stale(org, created, etype):
+            return {"handled": False, "stale": True}
         _apply_subscription(
             session, org,
             customer_id=obj.get("customer"),
@@ -125,6 +139,7 @@ def handle_webhook_event(session: Session, event) -> dict:
             # Checkout completing means payment succeeded; the subscription.updated that follows
             # carries the authoritative status and converges to the same state.
             status="active",
+            event_at=created,
         )
         return {"handled": True, "plan": org.plan}
 
@@ -139,26 +154,47 @@ def handle_webhook_event(session: Session, event) -> dict:
         if org is None:
             log.warning("stripe_subscription_unknown_org", customer=obj.get("customer"))
             return {"handled": False}
+        if _is_stale(org, created, etype):
+            return {"handled": False, "stale": True}
         _apply_subscription(
             session, org,
             customer_id=obj.get("customer"),
             subscription_id=obj.get("id"),
             status=status,
+            event_at=created,
         )
         return {"handled": True, "plan": org.plan}
 
     return {"handled": False, "ignored": etype}
 
 
+def _is_stale(org: Organization, created: int, etype: str) -> bool:
+    """Whether this event predates the one already applied to the org.
+
+    Strictly older, so the two events of a single upgrade (checkout + subscription.updated) can
+    share a second and both apply — they converge on the same state anyway. Equal-or-newer wins,
+    which also keeps a plain redelivery of the newest event working exactly as before.
+    """
+    applied = org.subscription_event_at
+    if applied is None or created >= applied:
+        return False
+    log.info(
+        "stripe_event_stale_ignored",
+        organization_id=org.id, event_type=etype, created=created, applied=applied,
+    )
+    return True
+
+
 def _apply_subscription(
     session: Session, org: Organization, *, customer_id: str | None,
-    subscription_id: str | None, status: str,
+    subscription_id: str | None, status: str, event_at: int = 0,
 ) -> None:
     if customer_id:
         org.stripe_customer_id = customer_id
     if subscription_id:
         org.stripe_subscription_id = subscription_id
     org.subscription_status = status
+    org.subscription_event_at = max(event_at, org.subscription_event_at or 0)
     # Never touch an operator account: `unlimited` is set via SQL and owns its plan outright —
     # a stray subscription event against it records the status but must not downgrade the plan.
     if org.plan != PLAN_UNLIMITED:

--- a/backend/tracely/services/quota_service.py
+++ b/backend/tracely/services/quota_service.py
@@ -120,16 +120,26 @@ async def quota_gate(project_id: str, session: AsyncSession) -> None:
 
     limit = int(limit_raw) if limit_raw else None
     if limit is not None and used is not None and used >= limit:
-        raise HTTPException(
-            status_code=429,
-            detail=(
-                f"monthly trace quota reached ({limit:,} traces on the "
-                f"{'Pro' if limit == settings.pro_trace_limit else 'Free'} plan) — "
-                f"upgrade at {settings.app_base_url.rstrip('/')}/settings/billing"
-            ),
-            # Most OTLP exporters drop on 429; spec-compliant ones back off politely.
-            headers={"Retry-After": "3600"},
-        )
+        raise HTTPException(status_code=429, detail=_over_quota_detail(limit),
+                            # Most OTLP exporters drop on 429; spec-compliant ones back off.
+                            headers={"Retry-After": "3600"})
+
+
+def _over_quota_detail(limit: int) -> str:
+    """Why the trace was refused, and what to do about it.
+
+    The "upgrade" half is conditional on purpose: `BILLING_ENABLED` can be on while Stripe is
+    not configured (checkout answers 501), and telling someone to upgrade at a URL where they
+    physically cannot pay is a dead end at the worst possible moment. Without Stripe the quota is
+    still a real cap — it just has to be lifted by the operator, so say that instead.
+    """
+    from tracely.services.billing_service import stripe_configured
+
+    plan = "Pro" if limit == settings.pro_trace_limit else "Free"
+    reached = f"monthly trace quota reached ({limit:,} traces on the {plan} plan)"
+    if stripe_configured():
+        return f"{reached} — upgrade at {settings.app_base_url.rstrip('/')}/settings/billing"
+    return f"{reached} — contact the operator of this deployment to raise it"
 
 
 async def usage_snapshot(project_id: str, session: AsyncSession) -> dict:


### PR DESCRIPTION
Audit of the monetisation path ahead of enabling it, plus the defects that are wrong under **any** pricing policy. **`billing_enabled` is still `False`** — flipping it is the human's call and is not in this PR.

## Audit

### a. Flip-day blast radius — yes, this is live-customer-affecting

Every existing organization is on `free`. `0021` added `projects.plan NOT NULL DEFAULT 'free'` (`0021_billing.py:31`) and `0023` backfilled orgs from the best plan among a user's projects, defaulting `'free'` (`0023_organizations.py:154,161`). `Organization.plan` carries `server_default="free"` (`models.py:70`). Nothing grandfathers anyone; `unlimited` is operator-only, set by SQL.

**What actually happens the moment the flag flips**, in severity order:

1. Every org gets a **20k traces/month** cap (`quota_service.py:_usage_from_pg` → `trace_limit_for`, `domain/billing.py:34`). **Not instant** — `record_ingested_traces` returns early while the flag is off (`quota_service.py:63`), so no `UsageCounter` row exists and everyone starts that month at 0. A customer is only cut off after ingesting 20k traces in the remainder of the current month. So: no immediate outage, but **any customer above 20k/month starts 429ing mid-month**.
2. Workspace and seat caps switch on (`provisioning.py:137,159`) — 3/3 on free. Existing over-cap orgs are **not** broken, they just cannot add a 4th.
3. `max_organizations_per_user=1` starts applying (`provisioning.py:198-206`) — again, only to new creation.

Blast radius is real but bounded, and entirely about #1. Grandfathering is a policy call — Q1 below.

**What makes grandfathering safe to execute:** `_apply_subscription` refuses to move an org off `unlimited` (`billing_service.py`, the `if org.plan != PLAN_UNLIMITED` guard) and `plan_for_subscription_status` never *returns* `unlimited` (`domain/billing.py:66`). So an operator-set `unlimited` cohort cannot be clobbered afterwards by a stray, out-of-order, or replayed subscription event — the SQL that grandfathers people stays true. Combined with the ordering guard added in this PR, an `UPDATE organizations SET plan='unlimited' WHERE …` is a durable decision rather than one Stripe can quietly undo.

### b. Truth-in-advertising

| Landing (`Landing.tsx:84-118`) | Code | |
|---|---|---|
| Free 20k traces | `free_trace_limit=20_000` | ✅ |
| Team 1M traces | `pro_trace_limit=1_000_000` | ✅ |
| Free 3 workspaces / 3 seats | `free_workspace_limit=3`, `free_seat_limit=3` | ✅ |
| Team 10 / 10 | `pro_*_limit=10` | ✅ |
| Free **7-day** retention | ClickHouse TTL is a flat **90 days** for everyone (`ddl/0001_events.up.sql:91`, `0003_events_ttl.up.sql:4`) | ⚠️ free over-delivers 13× |
| Team **90-day** retention | same flat 90 days | ✅ delivered |
| Free "CI gate on one agent" | not enforced anywhere | ⚠️ over-delivers |

Nothing is under-delivered — every mismatch is in the customer's favour, so no defect to fix here, but two of Team's headline reasons to pay are things Free already gets. Q2/Q3.

### c. Money paths

- **Signature verified** ✅ — `construct_event` over raw bytes (`billing.py:105-110`, `billing_service.py:96-103`), 400 on failure, and the app refuses to boot with a Stripe key and no webhook secret (`config.py:344`).
- **Idempotent under replay of the same event** ✅ — writes are state-sets, not increments.
- **Idempotent under replay of an OLDER event** ❌ — **fixed here.** See below.
- **Downgrade on failed/expired payment** ✅ — `plan_for_subscription_status` maps anything outside `{active, trialing, past_due}` to free; `past_due` deliberately stays paid so dunning doesn't flip a customer mid-cycle (`domain/billing.py:27,66`).
- **Upgrade on success** ✅ — with a metadata fallback for subscription events arriving before `checkout.session.completed` (`billing_service.py:126-140`).
- **Abandoned checkout** ✅ — no event, no plan change. It does leave `stripe_customer_id` stamped (`billing_service.py:63-67`), which is harmless and makes the portal work later. Now covered by a test.
- ⚠️ Not fixed, reporting per instructions: `checkout.session.completed` forces `status="active"` without reading `payment_status`, so a delayed-payment method grants Pro before the money lands. The following `subscription.updated` converges. Defensible as written.
- ⚠️ Two rapid checkout clicks can create two subscriptions on one customer (the guard is on `subscription_status`, not on an in-flight session). Fixing it means querying Stripe in the checkout path — Q6.

### d. Enforcement path — fail-open confirmed, and it is the only one

`quota_gate` returns (allows) on any Postgres error (`quota_service.py:113-115`) and treats a Redis error as a cache miss (`:104-106`). Correct as designed — a quota is a product limit, not a security boundary — so left alone and now **asserted by a test** rather than assumed. The counting side fails in the same direction: Redis down → batch uncounted, Postgres failing after SADD → delta lost (`:75-88`). Both **undercount**, so the leak is toward the customer, never toward over-billing. I found no path that silently grants paid capacity.

### e. Test coverage before this PR

Good on: plan mapping, pooling across an org, unlimited never gated, cache-before-Postgres, role checks on checkout, bad signature, 5xx-so-Stripe-redelivers, same-event replay. **Gaps:** out-of-order/stale delivery (the bug below), the gate failing open on a Postgres error, abandoned checkout, the 429 message when Stripe is unconfigured — and the suite was reading a real `.env` Stripe key.

## Fixed

1. **Stale Stripe events re-applied.** Stripe guarantees neither order nor single delivery and retries for up to three days, so a `subscription.updated(active)` could land *after* a `subscription.deleted` and put a cancelled account back on Pro, for free, silently. `organizations.subscription_event_at` (**migration 0031**) records the newest event applied; strictly older ones are dropped. Equal timestamps still apply, so the two events of a single upgrade both land. An event with no `created` reads as 0 and fails closed.
2. **The 429 pointed at a dead upgrade page.** `BILLING_ENABLED` can be on while Stripe is unconfigured (checkout 501s) — the cap is real, but the message told people to pay somewhere they can't. It now names the operator instead.
3. **The suite was not hermetic on the money path.** `Settings` reads `.env`, and the dev `.env` here holds a **live** (`sk_live_…`) Stripe secret, so `stripe_configured()` answered True locally and False in CI — a different suite in each place, and one careless test away from touching a real Stripe account. Hard-off in `conftest.py`, matching the four pre-existing hard-offs. It immediately caught a test that only passed because of the local key.

Tests added for every money path touched: stale redelivery, out-of-order first delivery, a newer event still winning, the shared-second case, missing `created`, abandoned checkout, both 429 messages, and the gate failing open on a Postgres outage.

## Verification

`uv run pytest -q backend/tests sdk/tests` → **1000 passed, 30 skipped** · `ruff check .` → clean · `billing_enabled` still `False` (`config.py:100`) · no Stripe keys added, no `.env` touched, no live API call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
