### PR TITLE
fix(frontend): let the marketing SEO pages through both auth middleware allowlists

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -9,6 +9,9 @@ const SESSION_COOKIE = "tracely_session";
 
 const PUBLIC = [
   /^\/$/, // the marketing landing page
+  // The rest of the (marketing) group — every route app/sitemap.ts advertises. Behind the wall they
+  // 307 to /login, so Google indexes a login page at a URL we told it to crawl.
+  /^\/(llm-evaluation|llm-as-a-judge|langfuse-alternatives|agent-skill)$/,
   /^\/login/,
   /^\/register/,
   /^\/accept-invite/,
@@ -34,6 +37,10 @@ export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
     // one of the two lists is public in local mode and a redirect loop in Clerk mode.
     const isPublicClerk = createRouteMatcher([
       "/",
+      "/llm-evaluation",
+      "/llm-as-a-judge",
+      "/langfuse-alternatives",
+      "/agent-skill",
       "/sign-in(.*)",
       "/sign-up(.*)",
       "/share/(.*)",


### PR DESCRIPTION
`frontend/app/sitemap.ts` advertises `/llm-evaluation`, `/llm-as-a-judge`, `/langfuse-alternatives` and `/agent-skill` as public indexable routes, and all four exist as `(marketing)` pages — but `middleware.ts` only exempted `/`. In `AUTH_MODE=local` they 307'd to `/login`; in clerk mode `auth.protect()` blocked them. So Google was crawling URLs we told it about and indexing a login page — the same failure the `sitemap.xml`/`robots.txt` exemption right below was added to fix.

Adds the four paths to `PUBLIC` (one anchored alternation regex) and to the Clerk `createRouteMatcher` list, keeping the two lists in sync as the comment there requires. No other behaviour changes.

Closes #80