### PR TITLE
chore: drop dead `make website` target, add migrate-chat to .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help infra-up infra-down infra-prune install migrate migrate-ch migrate-pg seed demo backend workers frontend docs website test send-trace demo-failures gate replay sdk-example auto-openai auto-agent run-all-examples seed-demo seed-regression fmt
+.PHONY: help infra-up infra-down infra-prune install migrate migrate-ch migrate-pg migrate-chat seed demo backend workers frontend docs test send-trace demo-failures gate replay sdk-example auto-openai auto-agent run-all-examples seed-demo seed-regression fmt
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -44,9 +44,6 @@ frontend:    ## run Next.js on :3000
 
 docs:        ## run the SDK documentation site (Nextra) on :3002
 	cd docs && pnpm install && pnpm dev
-
-website:     ## run the marketing site on :3003
-	cd website && pnpm install && pnpm dev
 
 test:        ## run backend tests
 	uv run pytest -q backend/tests


### PR DESCRIPTION
`make website` ran `cd website && pnpm install && pnpm dev`, but `website/` no longer exists (removed in af2fff8) and nothing else in the repo references it — the target just fails with `cd: no such file or directory`. Deleted the target and its `.PHONY` entry. Also added `migrate-chat` to `.PHONY`; it's a real target used by `make migrate` but was missing from the list.

Closes #82