### PR TITLE
chore: make `make test` run sdk/tests too, matching CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ uv run ruff check . && uv run ruff format .
 cd frontend && pnpm test        # vitest; pnpm test:watch; pnpm build type-checks (tsc) + lints
 ```
 
-`make test` only runs `backend/tests`; run `sdk/tests` too before pushing. Alembic: `cd backend && uv run alembic revision -m "…"` / `alembic upgrade head`. ClickHouse migrations are `*.up.sql` files in `backend/tracely/infrastructure/clickhouse/ddl/` applied by `python -m tracely.infrastructure.clickhouse.migrations`.
+Alembic: `cd backend && uv run alembic revision -m "…"` / `alembic upgrade head`. ClickHouse migrations are `*.up.sql` files in `backend/tracely/infrastructure/clickhouse/ddl/` applied by `python -m tracely.infrastructure.clickhouse.migrations`.
 
 Whole stack in Docker: `docker compose up -d --build --wait` → UI on **:3001**, backend on **:8000** (remap with `TRACELY_WEB_PORT` / `TRACELY_BACKEND_PORT`). `make frontend` runs plain `next dev` (:3000) — use `cd frontend && pnpm dev -p 3001` to match Docker.
 

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ frontend:    ## run Next.js on :3000
 docs:        ## run the SDK documentation site (Nextra) on :3002
 	cd docs && pnpm install && pnpm dev
 
-test:        ## run backend tests
-	uv run pytest -q backend/tests
+test:        ## run backend + sdk tests (what CI runs)
+	uv run pytest -q backend/tests sdk/tests
 
 send-trace:  ## post a sample OTLP trace to the running API
 	uv run python scripts/send_test_trace.py


### PR DESCRIPTION
`make test` ran only `backend/tests` while CI runs `backend/tests sdk/tests`, so a green local run could still fail the gate — which is why CLAUDE.md carried the "run `sdk/tests` too before pushing" caveat.

- `Makefile`: `test` target now runs `uv run pytest -q backend/tests sdk/tests` (both suites are infra-free, ~6s), help text updated.
- `CLAUDE.md`: removed the now-unnecessary caveat.

Closes #84