### PR TITLE
docs: note the (n−1)/√n bound that makes MIN_OUTLIER_POINTS dead

### DIFF
--- a/backend/tracely/domain/analysis/statistics.py
+++ b/backend/tracely/domain/analysis/statistics.py
@@ -17,7 +17,9 @@ import math
 import numpy as np
 
 # Minimums (mirror the source spec): a correlation needs at least this many shared conversations;
-# an outlier metric needs at least this many values to have a meaningful mean/spread.
+# an outlier metric needs at least this many values to have a meaningful mean/spread. The outlier
+# floor is a formality: with the population std, |z| ≤ (n−1)/√n, so nothing clears `OUTLIER_Z` = 2.0
+# until n ≥ 6 (n=5 caps at 1.79).
 MIN_CORR_POINTS = 3
 MIN_OUTLIER_POINTS = 2
 # |z| above this flags an outlier; the high/medium cutoffs grade its severity.


### PR DESCRIPTION
`zscore_outliers` uses the population std (`arr.std()`), for which `|z| ≤ (n−1)/√n`. Nothing can exceed `OUTLIER_Z = 2.0` until n ≥ 6 (n=5 caps at 1.79), so the `MIN_OUTLIER_POINTS = 2` guard never rejects anything that would otherwise be flagged — but the comment ("at least this many values to have a meaningful mean/spread") reads as if 2 were the real floor. Comment now states the bound and the true n ≥ 6 threshold. Constant left at 2: no behaviour change, smallest diff.

Closes #86