### PR TITLE
fix(compose): pass SENTRY_DSN / SENTRY_ENVIRONMENT through to the containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,9 @@ x-app-env: &app-env
   RESEND_API_KEY: ${RESEND_API_KEY:-}
   EMAIL_FROM: "${EMAIL_FROM:-Tracely <onboarding@resend.dev>}"
   APP_BASE_URL: ${APP_BASE_URL:-http://localhost:3001}
+  # Error tracking (Sentry) — optional; the API and the worker each init on their own when set.
+  SENTRY_DSN: ${SENTRY_DSN:-}
+  SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}
   # Hosted-cloud billing — all off by default; self-hosters never need these. BILLING_ENABLED
   # turns on the monthly trace quota (counted in the WORKER, enforced in the API — the shared
   # anchor is what makes sure both see the flag). REQUIRE_PROJECT_LLM_KEY makes server-wide LLM


### PR DESCRIPTION
`sentry_dsn` / `sentry_environment` exist in `config.py` and are read by both `api/main.py` and the Celery worker, and `guides/DEPLOY.md` tells people to set them — but they were missing from `docker-compose.yml`'s `x-app-env` anchor, so setting `SENTRY_DSN` in `.env` had no effect on the Docker stack (exactly the failure mode CLAUDE.md's "New backend env var?" rule warns about).

Adds `SENTRY_DSN: ${SENTRY_DSN:-}` and `SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}` to the anchor alongside the other optional credentials. Blank by default, so nothing changes for anyone not using Sentry.

Closes #88