### PR TITLE
docs: document the LLM keys in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,18 @@ S3_EVENT_PREFIX=events/
 CLICKHOUSE_ASYNC_INSERT=1            # rely on CH server-side batching (Celery has no shared in-proc buffer)
 INGESTION_DELAY_SECONDS=0            # OTLP path: no artificial delay (mirrors Langfuse getDelay otel branch)
 
+# ── LLM access ─────────────────────────────────────────────────────────────────
+# Every judge, failure-intelligence and meta-analysis call goes through LangChain `create_agent`
+# on OpenRouter (embeddings via its OpenAI-compatible /embeddings endpoint) — OPENROUTER_API_KEY
+# alone is enough. Blank = the pipeline still runs, but evaluators degrade to no-ops.
+OPENROUTER_API_KEY=
+# Legacy direct-endpoint fallbacks, used only when no OpenRouter key is set.
+# OPENAI_API_KEY=
+# LLM_JUDGE_API_KEY=
+# Encrypts a workspace's own OpenRouter key (Settings -> LLM key) at rest — only needed once a
+# workspace brings its own. Any string >=32 chars; generate with `openssl rand -base64 32`.
+# SECRETS_ENCRYPTION_KEY=
+
 # ── Auth & multi-tenancy ───────────────────────────────────────────────────────
 # dev   = no human login; the ingest key is the only credential (default, unchanged behavior).
 # local = self-host email/password (Railway). Requires SESSION_SECRET. First user = OWNER, then invite-only.

--- a/frontend/app/lib/meta.ts
+++ b/frontend/app/lib/meta.ts
@@ -7,8 +7,10 @@ const META_PREFIX = "tracely.metadata.";
 function coerce(v: string): unknown {
   if (v === "true") return true;
   if (v === "false") return false;
-  if (v !== "" && !Number.isNaN(Number(v))) return Number(v);
   const t = v.trim();
+  // only coerce when the number round-trips exactly — `"0098231"`, `"1.0"`, `"0x10"`, `"1e3"` are
+  // ids/versions the user set, and rewriting them breaks both display and the search haystack.
+  if (t !== "" && String(Number(t)) === t) return Number(t);
   if (t.startsWith("{") || t.startsWith("[")) {
     try {
       return JSON.parse(t);


### PR DESCRIPTION
`.env.example` covered Postgres, ClickHouse, Redis, S3, auth, Resend and PostHog but never the LLM credentials, so anyone following the quickstart's `cp .env.example .env` got a stack whose judge, failure-intelligence and meta-analysis calls silently degraded to no-ops.

Adds an `── LLM access ──` block mirroring the `x-app-env` comments in `docker-compose.yml`:
- `OPENROUTER_API_KEY=` — uncommented, since it alone is enough (chat *and* embeddings).
- `OPENAI_API_KEY` / `LLM_JUDGE_API_KEY` — commented, noted as the legacy direct-endpoint fallbacks.
- `SECRETS_ENCRYPTION_KEY` — commented, noted as only needed once a workspace brings its own key.

Comments only; no code or behavior change.

Closes #92