### PR TITLE
feat(traces): make the Agent filter searchable and naturally sorted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ out/
 # build artifacts
 dist/
 dist-sdk/
+.env.bak-video

--- a/frontend/app/components/AgentPicker.test.tsx
+++ b/frontend/app/components/AgentPicker.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentPicker } from "./AgentPicker";
+
+const AGENTS = [
+  { id: "i10", slug: "agent_10", display_name: "Ten" },
+  { id: "i2", slug: "agent_2", display_name: "Two" },
+  { id: "i1", slug: "Beta", display_name: "Beta" },
+];
+
+const slugs = () =>
+  Array.from(document.querySelectorAll("datalist option")).map((o) => (o as HTMLOptionElement).value);
+
+describe("AgentPicker", () => {
+  it("lists agents in natural order, digits numerically", () => {
+    render(<AgentPicker agents={AGENTS} value="" onChange={() => {}} allLabel="All agents" />);
+    expect(slugs()).toEqual(["agent_2", "agent_10", "Beta"]);
+  });
+
+  it("keeps the caller's order when sort is off", () => {
+    render(<AgentPicker agents={AGENTS} value="" onChange={() => {}} sort={false} />);
+    expect(slugs()).toEqual(["agent_10", "agent_2", "Beta"]);
+  });
+
+  it("commits only on an exact slug, not on every keystroke", async () => {
+    const onChange = vi.fn();
+    render(<AgentPicker agents={AGENTS} value="" onChange={onChange} allLabel="All agents" />);
+    await userEvent.type(screen.getByRole("combobox"), "agent_2");
+    expect(onChange.mock.calls).toEqual([["i2"]]); // "a", "ag", … matched nothing
+  });
+
+  it("stores the field the caller asked for", async () => {
+    const onChange = vi.fn();
+    render(<AgentPicker agents={AGENTS} value="" onChange={onChange} by="slug" allLabel="all" />);
+    await userEvent.type(screen.getByRole("combobox"), "Beta");
+    expect(onChange).toHaveBeenCalledWith("Beta");
+  });
+
+  it("clearing the box means all agents", async () => {
+    const onChange = vi.fn();
+    render(<AgentPicker agents={AGENTS} value="i2" onChange={onChange} allLabel="All agents" />);
+    await userEvent.clear(screen.getByRole("combobox"));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("cannot clear a required pick — half-typed text snaps back on blur", async () => {
+    const onChange = vi.fn();
+    render(<AgentPicker agents={AGENTS} value="i2" onChange={onChange} />);
+    const box = screen.getByRole("combobox");
+    await userEvent.clear(box);
+    expect(onChange).not.toHaveBeenCalled();
+    await userEvent.tab();
+    expect(box).toHaveValue("agent_2");
+  });
+
+  it("follows the value when it changes from outside", async () => {
+    function Harness() {
+      const [v, setV] = useState("i2");
+      return (
+        <>
+          <button onClick={() => setV("")}>reset</button>
+          <AgentPicker agents={AGENTS} value={v} onChange={setV} allLabel="All agents" />
+        </>
+      );
+    }
+    render(<Harness />);
+    expect(screen.getByRole("combobox")).toHaveValue("agent_2");
+    await userEvent.click(screen.getByText("reset"));
+    expect(screen.getByRole("combobox")).toHaveValue("");
+  });
+});

--- a/frontend/app/components/AgentPicker.test.tsx
+++ b/frontend/app/components/AgentPicker.test.tsx
@@ -10,49 +10,71 @@ const AGENTS = [
   { id: "i1", slug: "Beta", display_name: "Beta" },
 ];
 
-const slugs = () =>
-  Array.from(document.querySelectorAll("datalist option")).map((o) => (o as HTMLOptionElement).value);
+const box = () => screen.getByRole("combobox");
+const rows = () => screen.getAllByRole("option").map((o) => o.textContent?.replace(/^✓/, "").trim());
 
 describe("AgentPicker", () => {
-  it("lists agents in natural order, digits numerically", () => {
+  it("lists agents in natural order, digits numerically", async () => {
     render(<AgentPicker agents={AGENTS} value="" onChange={() => {}} allLabel="All agents" />);
-    expect(slugs()).toEqual(["agent_2", "agent_10", "Beta"]);
+    await userEvent.click(box());
+    expect(rows()).toEqual(["All agents", "agent_2", "agent_10", "Beta"]);
   });
 
-  it("keeps the caller's order when sort is off", () => {
+  it("keeps the caller's order when sort is off", async () => {
     render(<AgentPicker agents={AGENTS} value="" onChange={() => {}} sort={false} />);
-    expect(slugs()).toEqual(["agent_10", "agent_2", "Beta"]);
+    await userEvent.click(box());
+    expect(rows()).toEqual(["agent_10", "agent_2", "Beta"]);
   });
 
-  it("commits only on an exact slug, not on every keystroke", async () => {
+  it("filters on a substring, not just a prefix", async () => {
+    render(<AgentPicker agents={AGENTS} value="" onChange={() => {}} allLabel="All agents" />);
+    await userEvent.type(box(), "et");
+    expect(rows()).toEqual(["Beta"]); // the "all agents" row drops out of a search
+  });
+
+  it("typing filters but never commits — only a click does", async () => {
     const onChange = vi.fn();
     render(<AgentPicker agents={AGENTS} value="" onChange={onChange} allLabel="All agents" />);
-    await userEvent.type(screen.getByRole("combobox"), "agent_2");
-    expect(onChange.mock.calls).toEqual([["i2"]]); // "a", "ag", … matched nothing
+    await userEvent.type(box(), "agent_2");
+    expect(onChange).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("option", { name: /agent_2/ }));
+    expect(onChange).toHaveBeenCalledWith("i2");
   });
 
   it("stores the field the caller asked for", async () => {
     const onChange = vi.fn();
     render(<AgentPicker agents={AGENTS} value="" onChange={onChange} by="slug" allLabel="all" />);
-    await userEvent.type(screen.getByRole("combobox"), "Beta");
+    await userEvent.click(box());
+    await userEvent.click(screen.getByRole("option", { name: /Beta/ }));
     expect(onChange).toHaveBeenCalledWith("Beta");
   });
 
-  it("clearing the box means all agents", async () => {
+  it("arrow keys + Enter pick a row", async () => {
+    const onChange = vi.fn();
+    render(<AgentPicker agents={AGENTS} value="" onChange={onChange} />);
+    await userEvent.click(box());
+    await userEvent.keyboard("{ArrowDown}{Enter}"); // agent_2 → agent_10
+    expect(onChange).toHaveBeenCalledWith("i10");
+  });
+
+  it("offers 'all agents' only where the caller allows an empty value", async () => {
+    const { unmount } = render(<AgentPicker agents={AGENTS} value="i2" onChange={() => {}} />);
+    await userEvent.click(box());
+    expect(rows()).not.toContain("All agents");
+    unmount();
+
     const onChange = vi.fn();
     render(<AgentPicker agents={AGENTS} value="i2" onChange={onChange} allLabel="All agents" />);
-    await userEvent.clear(screen.getByRole("combobox"));
+    await userEvent.click(box());
+    await userEvent.click(screen.getByRole("option", { name: "All agents" }));
     expect(onChange).toHaveBeenCalledWith("");
   });
 
-  it("cannot clear a required pick — half-typed text snaps back on blur", async () => {
-    const onChange = vi.fn();
-    render(<AgentPicker agents={AGENTS} value="i2" onChange={onChange} />);
-    const box = screen.getByRole("combobox");
-    await userEvent.clear(box);
-    expect(onChange).not.toHaveBeenCalled();
-    await userEvent.tab();
-    expect(box).toHaveValue("agent_2");
+  it("a half-typed search never survives the panel closing", async () => {
+    render(<AgentPicker agents={AGENTS} value="i2" onChange={() => {}} />);
+    await userEvent.type(box(), "Bet");
+    await userEvent.keyboard("{Escape}");
+    expect(box()).toHaveValue("agent_2");
   });
 
   it("follows the value when it changes from outside", async () => {
@@ -66,8 +88,8 @@ describe("AgentPicker", () => {
       );
     }
     render(<Harness />);
-    expect(screen.getByRole("combobox")).toHaveValue("agent_2");
+    expect(box()).toHaveValue("agent_2");
     await userEvent.click(screen.getByText("reset"));
-    expect(screen.getByRole("combobox")).toHaveValue("");
+    expect(box()).toHaveValue("");
   });
 });

--- a/frontend/app/components/AgentPicker.tsx
+++ b/frontend/app/components/AgentPicker.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { AgentRow } from "@/app/lib/api";
+
+/** The project's agent registry as a native searchable combobox.
+ *
+ *  A `<select>` over a registry with dozens of agents is a wall to scroll, so this is
+ *  `<input list>` + `<datalist>`: type-to-filter for free, in every browser, no dependency.
+ *  Typing only filters — a selection commits on an exact slug (or, where `allLabel` says an
+ *  empty box means "all agents", on clearing it), so half-typed text never re-queries the
+ *  server or drops a required pick. Anything left half-typed snaps back on blur. */
+export function AgentPicker({
+  agents,
+  value,
+  onChange,
+  by = "id",
+  allLabel,
+  hint,
+  sort = true,
+  id,
+  ariaLabel,
+  className,
+  disabled,
+}: {
+  agents: AgentRow[];
+  value: string; // the picked agent's `by` field; "" = every agent (only where allLabel is set)
+  onChange: (value: string) => void;
+  by?: "id" | "slug"; // which field the caller stores
+  allLabel?: string; // placeholder for the empty box; omitted = a pick is required
+  hint?: (a: AgentRow) => string; // secondary text (a count); Chrome/Firefox render it, Safari doesn't
+  sort?: boolean; // off where the caller curates the order (e.g. agents with cases first)
+  id?: string;
+  ariaLabel?: string;
+  className?: string;
+  disabled?: boolean;
+}) {
+  // Natural order, so agent_2 sorts before agent_10 instead of after it.
+  const options = useMemo(
+    () =>
+      sort
+        ? [...agents].sort((a, b) => a.slug.localeCompare(b.slug, undefined, { numeric: true, sensitivity: "base" }))
+        : agents,
+    [agents, sort],
+  );
+
+  const selected = agents.find((a) => a[by] === value);
+  const [text, setText] = useState(selected?.slug ?? "");
+  // Follow the value when it moves from outside — a filter reset, a workspace switch.
+  useEffect(() => setText(selected?.slug ?? ""), [selected?.slug]);
+
+  function type(next: string) {
+    setText(next);
+    const hit = agents.find((a) => a.slug === next);
+    if (hit) {
+      if (hit[by] !== value) onChange(hit[by]);
+    } else if (!next.trim() && allLabel && value) {
+      onChange("");
+    }
+  }
+
+  return (
+    <>
+      <input
+        id={id}
+        type="search"
+        list={`${id ?? "agent-picker"}-options`}
+        value={text}
+        onChange={(e) => type(e.target.value)}
+        onBlur={() => setText(selected?.slug ?? "")}
+        disabled={disabled}
+        placeholder={allLabel ?? "Search agents…"}
+        aria-label={ariaLabel ?? "Agent"}
+        className={className}
+      />
+      <datalist id={`${id ?? "agent-picker"}-options`}>
+        {options.map((a) => (
+          <option key={a.id} value={a.slug} label={hint?.(a)} />
+        ))}
+      </datalist>
+    </>
+  );
+}

--- a/frontend/app/components/AgentPicker.tsx
+++ b/frontend/app/components/AgentPicker.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { AgentRow } from "@/app/lib/api";
 
-/** The project's agent registry as a native searchable combobox.
+/** The project's agent registry as a searchable combobox.
  *
- *  A `<select>` over a registry with dozens of agents is a wall to scroll, so this is
- *  `<input list>` + `<datalist>`: type-to-filter for free, in every browser, no dependency.
- *  Typing only filters — a selection commits on an exact slug (or, where `allLabel` says an
- *  empty box means "all agents", on clearing it), so half-typed text never re-queries the
- *  server or drops a required pick. Anything left half-typed snaps back on blur. */
+ *  A `<select>` over a registry with dozens of agents is a wall to scroll, and the two native
+ *  fixes for that — `<select>` and `<datalist>` — both render an OS popup we cannot theme, a
+ *  light-grey system panel dropped on top of a dark app. So the list is ours: an input that
+ *  filters, a panel that looks like the rest of the product, and substring matching (the
+ *  datalist popup only prefix-matches in Safari).
+ *
+ *  Typing filters, it never commits — a pick lands on click or Enter, and anything half-typed
+ *  reverts when the panel closes, so a required selection can't be lost by wandering off. */
 export function AgentPicker({
   agents,
   value,
@@ -27,16 +31,24 @@ export function AgentPicker({
   value: string; // the picked agent's `by` field; "" = every agent (only where allLabel is set)
   onChange: (value: string) => void;
   by?: "id" | "slug"; // which field the caller stores
-  allLabel?: string; // placeholder for the empty box; omitted = a pick is required
-  hint?: (a: AgentRow) => string; // secondary text (a count); Chrome/Firefox render it, Safari doesn't
+  allLabel?: string; // the "no filter" row; omitted = a pick is required
+  hint?: (a: AgentRow) => string; // secondary text on the row (a count)
   sort?: boolean; // off where the caller curates the order (e.g. agents with cases first)
   id?: string;
   ariaLabel?: string;
   className?: string;
   disabled?: boolean;
 }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+
+  const selected = agents.find((a) => a[by] === value);
+
   // Natural order, so agent_2 sorts before agent_10 instead of after it.
-  const options = useMemo(
+  const ordered = useMemo(
     () =>
       sort
         ? [...agents].sort((a, b) => a.slug.localeCompare(b.slug, undefined, { numeric: true, sensitivity: "base" }))
@@ -44,40 +56,164 @@ export function AgentPicker({
     [agents, sort],
   );
 
-  const selected = agents.find((a) => a[by] === value);
-  const [text, setText] = useState(selected?.slug ?? "");
-  // Follow the value when it moves from outside — a filter reset, a workspace switch.
-  useEffect(() => setText(selected?.slug ?? ""), [selected?.slug]);
+  const needle = query.trim().toLowerCase();
+  const matches = useMemo(
+    () => (needle ? ordered.filter((a) => a.slug.toLowerCase().includes(needle)) : ordered),
+    [ordered, needle],
+  );
+  // `null` is the "every agent" row — only offered where the caller allows an empty value.
+  const rows: (AgentRow | null)[] = allLabel && !needle ? [null, ...matches] : matches;
 
-  function type(next: string) {
-    setText(next);
-    const hit = agents.find((a) => a.slug === next);
-    if (hit) {
-      if (hit[by] !== value) onChange(hit[by]);
-    } else if (!next.trim() && allLabel && value) {
-      onChange("");
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  // Closing is always a full reset: the box shows what is actually selected, never a stale search.
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  // Keep the highlighted row in view while arrowing through a long registry.
+  useEffect(() => {
+    listRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [active, open]);
+
+  function commit(a: AgentRow | null) {
+    const next = a ? a[by] : "";
+    if (next !== value) onChange(next);
+    setOpen(false);
+  }
+
+  function onKey(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      setOpen(false);
+      return;
+    }
+    if (e.key === "Enter") {
+      if (open && rows[active] !== undefined) {
+        e.preventDefault();
+        commit(rows[active]);
+      }
+      return;
+    }
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
+      const step = e.key === "ArrowDown" ? 1 : -1;
+      setActive((i) => (rows.length ? (i + step + rows.length) % rows.length : 0));
     }
   }
 
   return (
-    <>
+    <div ref={rootRef} className="relative">
       <input
         id={id}
-        type="search"
-        list={`${id ?? "agent-picker"}-options`}
-        value={text}
-        onChange={(e) => type(e.target.value)}
-        onBlur={() => setText(selected?.slug ?? "")}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+        autoComplete="off"
+        value={open ? query : selected?.slug ?? ""}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setActive(0);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onClick={() => setOpen(true)}
+        onKeyDown={onKey}
         disabled={disabled}
-        placeholder={allLabel ?? "Search agents…"}
+        placeholder={selected ? selected.slug : allLabel ?? "Search agents…"}
         aria-label={ariaLabel ?? "Agent"}
-        className={className}
+        className={clsx(className, "pr-7")}
       />
-      <datalist id={`${id ?? "agent-picker"}-options`}>
-        {options.map((a) => (
-          <option key={a.id} value={a.slug} label={hint?.(a)} />
-        ))}
-      </datalist>
+      {/* A chevron, so the box still reads as a picker rather than a text field. */}
+      <span
+        aria-hidden
+        className={clsx(
+          "pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-fg-faint transition-transform",
+          open && "rotate-180",
+        )}
+      >
+        <svg viewBox="0 0 12 12" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="1.6">
+          <path d="M3 4.5 6 7.5 9 4.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </span>
+
+      {open && (
+        <div
+          ref={listRef}
+          role="listbox"
+          // Keep focus in the input: a blur before the click would close the panel under the cursor.
+          onMouseDown={(e) => e.preventDefault()}
+          className="absolute left-0 top-full z-50 mt-2 max-h-72 w-full min-w-[17rem] overflow-y-auto rounded-xl border border-line bg-ink-800/95 p-1 shadow-panel backdrop-blur-md"
+        >
+          {rows.length === 0 && (
+            <div className="px-2.5 py-3 text-center text-[12px] text-fg-faint">No agent matches “{query}”</div>
+          )}
+          {rows.map((a, i) => {
+            const isSelected = a ? a[by] === value : !value;
+            return (
+              <button
+                key={a?.id ?? "__all"}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                data-active={i === active}
+                onMouseEnter={() => setActive(i)}
+                onClick={() => commit(a)}
+                className={clsx(
+                  "group relative flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors",
+                  i === active ? "bg-signal/10 text-fg" : "text-fg-muted",
+                )}
+              >
+                {i === active && (
+                  <span className="absolute left-0 top-1/2 h-4 w-[2px] -translate-y-1/2 rounded-r-full bg-signal shadow-[0_0_8px_rgb(var(--c-signal)/0.7)]" />
+                )}
+                <span
+                  aria-hidden
+                  className={clsx(
+                    "grid h-3.5 w-3.5 shrink-0 place-items-center text-[10px]",
+                    isSelected ? "text-signal" : "text-transparent",
+                  )}
+                >
+                  ✓
+                </span>
+                <span className={clsx("min-w-0 flex-1 truncate", a ? "font-mono text-[12px]" : "text-[12.5px]")}>
+                  {a ? highlight(a.slug, needle) : allLabel}
+                </span>
+                {a && hint && (
+                  <span className="shrink-0 font-mono text-[10px] uppercase tracking-wider text-fg-faint">
+                    {hint(a)}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Tint the matched span so it's obvious *why* a row survived the filter. */
+function highlight(slug: string, needle: string) {
+  if (!needle) return slug;
+  const at = slug.toLowerCase().indexOf(needle);
+  if (at < 0) return slug;
+  return (
+    <>
+      {slug.slice(0, at)}
+      <span className="text-signal">{slug.slice(at, at + needle.length)}</span>
+      {slug.slice(at + needle.length)}
     </>
   );
 }

--- a/frontend/app/components/MetaAnalysisPanel.tsx
+++ b/frontend/app/components/MetaAnalysisPanel.tsx
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { AgentPicker } from "@/app/components/AgentPicker";
 import { DocLink } from "@/app/components/DocLink";
 import { Badge } from "@/app/components/ui";
 
@@ -148,18 +149,14 @@ export function MetaAnalysisPanel() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <select
-            value={agentId}
-            onChange={(e) => setAgentId(e.target.value)}
-            className="rounded-lg border border-line bg-ink-900 px-2.5 py-1.5 text-[12.5px] text-fg outline-none focus:border-signal/50"
-          >
-            <option value={ALL}>All agents</option>
-            {agents.map((a) => (
-              <option key={a.id} value={a.id}>
-                {a.display_name}
-              </option>
-            ))}
-          </select>
+          <AgentPicker
+            agents={agents}
+            value={agentId === ALL ? "" : agentId}
+            onChange={(v) => setAgentId(v || ALL)}
+            allLabel="All agents"
+            id="meta-agent"
+            className="w-48 rounded-lg border border-line bg-ink-900 px-2.5 py-1.5 text-[12.5px] text-fg placeholder:text-fg-faint outline-none focus:border-signal/50"
+          />
           <button
             onClick={run}
             disabled={running}

--- a/frontend/app/components/RunGateButton.tsx
+++ b/frontend/app/components/RunGateButton.tsx
@@ -3,6 +3,7 @@
 import clsx from "clsx";
 import { useRouter } from "next/navigation";
 import { useMemo, useState, type ReactNode } from "react";
+import { AgentPicker } from "./AgentPicker";
 import { IconChevron, IconGate } from "./icons";
 import { Badge } from "./ui";
 import type { AgentRow } from "@/app/lib/api";
@@ -118,21 +119,19 @@ export function RunGateButton({
     <div className="flex flex-col items-end gap-1.5">
       <div className="flex items-center gap-2">
         {agents.length > 1 && (
-          <select
+          <AgentPicker
+            agents={agents}
             value={agentId}
-            onChange={(e) => {
-              setAgentId(e.target.value);
+            onChange={(v) => {
+              setAgentId(v);
               setOff(new Set()); // a pick belongs to the agent it was made for
             }}
-            aria-label="Agent to gate"
-            className="rounded-lg border border-line bg-ink-700 px-2.5 py-2 font-mono text-[12.5px] text-fg-muted transition-colors hover:border-line-bright focus:border-signal/50 focus:outline-none"
-          >
-            {agents.map((a) => (
-              <option key={a.id} value={a.id}>
-                {a.slug} ({caseCounts[a.id] ?? 0})
-              </option>
-            ))}
-          </select>
+            hint={(a) => `${caseCounts[a.id] ?? 0} cases`}
+            sort={false}
+            id="gate-agent"
+            ariaLabel="Agent to gate"
+            className="w-52 rounded-lg border border-line bg-ink-700 px-2.5 py-2 font-mono text-[12.5px] text-fg transition-colors hover:border-line-bright focus:border-signal/50 focus:outline-none"
+          />
         )}
         <button
           onClick={go}

--- a/frontend/app/components/ScenariosManager.tsx
+++ b/frontend/app/components/ScenariosManager.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import type { AgentRow, Scenario, ScenarioTurn } from "@/app/lib/api";
 import { listJudgeModels, type JudgeModelOption } from "@/app/lib/evaluators";
+import { AgentPicker } from "./AgentPicker";
 import { EndpointPanel } from "./EndpointPanel";
 import { TurnEditor, emptyTurn } from "./TurnEditor";
 import { Toggle } from "./Toggle";
@@ -130,18 +131,15 @@ export function ScenariosManager({
           <label className={LABEL} htmlFor="sc-agent">
             Agent
           </label>
-          <select
+          <AgentPicker
             id="sc-agent"
+            agents={agents}
             value={agentId}
-            onChange={(e) => setAgentId(e.target.value)}
-            className="mt-1 block rounded-lg border border-line bg-ink-700 px-2.5 py-2 font-mono text-[12.5px] text-fg-muted transition-colors hover:border-line-bright focus:border-signal/50 focus:outline-none"
-          >
-            {agents.map((a) => (
-              <option key={a.id} value={a.id}>
-                {a.slug} ({counts[a.id] ?? 0})
-              </option>
-            ))}
-          </select>
+            onChange={setAgentId}
+            hint={(a) => `${counts[a.id] ?? 0} scenarios`}
+            sort={false}
+            className="mt-1 block w-56 rounded-lg border border-line bg-ink-700 px-2.5 py-2 font-mono text-[12.5px] text-fg transition-colors hover:border-line-bright focus:border-signal/50 focus:outline-none"
+          />
         </div>
         <div className="flex flex-col items-end gap-1.5">
           <button

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -79,7 +79,9 @@ export function Sidebar({ me }: { me: Me | null }) {
         </div>
       </a>
 
-      <nav className="flex-1 space-y-7 px-3 py-1">
+      {/* min-h-0 + scroll: without it the nav grows past the viewport on a short window, the footer
+          gets pushed off the bottom edge and the account card ends up flush against it. */}
+      <nav className="min-h-0 flex-1 space-y-7 overflow-y-auto px-3 py-1">
         {NAV.map((sec) => (
           <div key={sec.group}>
             <div className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-faint">
@@ -122,7 +124,7 @@ export function Sidebar({ me }: { me: Me | null }) {
         ))}
       </nav>
 
-      <div className="border-t border-line px-4 py-4">
+      <div className="shrink-0 border-t border-line px-4 pb-5 pt-4">
         <AccountMenu me={me} />
         <div className="mt-3 px-1 font-mono text-[10px] text-fg-faint">v0.1.0 · MVP</div>
       </div>

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -81,7 +81,7 @@ export function Sidebar({ me }: { me: Me | null }) {
 
       {/* min-h-0 + scroll: without it the nav grows past the viewport on a short window, the footer
           gets pushed off the bottom edge and the account card ends up flush against it. */}
-      <nav className="min-h-0 flex-1 space-y-7 overflow-y-auto px-3 py-1">
+      <nav className="min-h-0 flex-1 space-y-7 overflow-y-auto px-3 pb-4 pt-1">
         {NAV.map((sec) => (
           <div key={sec.group}>
             <div className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-fg-faint">

--- a/frontend/app/components/TracesExplorer.tsx
+++ b/frontend/app/components/TracesExplorer.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AgentRow, ConvNode, SessionSort, SortOrder } from "../lib/api";
 import { mergeMeta, metaText } from "../lib/meta";
+import { AgentPicker } from "./AgentPicker";
 import { DateRangePicker } from "./DateRangePicker";
 import { TraceTable } from "./TraceTable";
 
@@ -43,7 +44,6 @@ export function TracesExplorer({
   // Server-side, like the range: a customer's conversations can sit past the loaded page, so
   // "only this agent" has to be a query, not a filter over the 50 rows on screen. "" = every agent.
   const [agentId, setAgentId] = useState("");
-  const [agentText, setAgentText] = useState(""); // what the Agent combobox shows (a slug, or free text while typing)
   // Sorting is server-side (see lib/api::SessionSort): the list is a page, so ordering only the
   // loaded rows would make "longest first" mean "longest of the 50 already on screen".
   const [sortBy, setSortBy] = useState<SortBy>(DEFAULT_SORT);
@@ -62,7 +62,6 @@ export function TracesExplorer({
     setRange({ from: null, to: null });
     setPreset("all");
     setAgentId("");
-    setAgentText("");
     setFilter("all");
     setSortBy(DEFAULT_SORT);
   }, [initial, initialHasMore]);
@@ -144,26 +143,8 @@ export function TracesExplorer({
     void load(range, sortBy, id, 0, true);
   }
 
-  // Combobox: typing filters the datalist locally; only an exact slug (or an empty box = all
-  // agents) is a real selection worth re-querying the server for.
-  function pickAgent(text: string) {
-    setAgentText(text);
-    const hit = agents.find((a) => a.slug === text);
-    if (hit) {
-      if (hit.id !== agentId) applyAgent(hit.id);
-    } else if (!text.trim() && agentId) {
-      applyAgent("");
-    }
-  }
-
   // Every filter refines the rows already loaded — none of them needs the server.
 
-
-  // Natural order, so agent_2 sorts before agent_10 instead of after it.
-  const sortedAgents = useMemo(
-    () => [...agents].sort((a, b) => a.slug.localeCompare(b.slug, undefined, { numeric: true, sensitivity: "base" })),
-    [agents],
-  );
 
   const counts = useMemo(
     () => ({
@@ -229,21 +210,16 @@ export function TracesExplorer({
             <span className="h-5 w-px bg-line" aria-hidden />
             <label className="flex items-center gap-2">
               <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-fg-faint">Agent</span>
-              <input
-                type="search"
-                list="traces-agent-slugs"
-                value={agentText}
-                onChange={(e) => pickAgent(e.target.value)}
+              <AgentPicker
+                agents={agents}
+                value={agentId}
+                onChange={applyAgent}
+                allLabel="All agents"
+                ariaLabel="Filter by agent"
+                id="traces-agent"
                 disabled={loading}
-                placeholder="All agents"
-                aria-label="Filter by agent"
                 className="w-52 rounded-lg border border-line bg-ink-800 px-2 py-1.5 font-mono text-[12px] text-fg placeholder:text-fg-faint transition-colors focus:border-signal/40 focus:outline-none disabled:opacity-50"
               />
-              <datalist id="traces-agent-slugs">
-                {sortedAgents.map((a) => (
-                  <option key={a.id} value={a.slug} />
-                ))}
-              </datalist>
             </label>
           </>
         )}

--- a/frontend/app/components/TracesExplorer.tsx
+++ b/frontend/app/components/TracesExplorer.tsx
@@ -43,6 +43,7 @@ export function TracesExplorer({
   // Server-side, like the range: a customer's conversations can sit past the loaded page, so
   // "only this agent" has to be a query, not a filter over the 50 rows on screen. "" = every agent.
   const [agentId, setAgentId] = useState("");
+  const [agentText, setAgentText] = useState(""); // what the Agent combobox shows (a slug, or free text while typing)
   // Sorting is server-side (see lib/api::SessionSort): the list is a page, so ordering only the
   // loaded rows would make "longest first" mean "longest of the 50 already on screen".
   const [sortBy, setSortBy] = useState<SortBy>(DEFAULT_SORT);
@@ -61,6 +62,7 @@ export function TracesExplorer({
     setRange({ from: null, to: null });
     setPreset("all");
     setAgentId("");
+    setAgentText("");
     setFilter("all");
     setSortBy(DEFAULT_SORT);
   }, [initial, initialHasMore]);
@@ -142,8 +144,26 @@ export function TracesExplorer({
     void load(range, sortBy, id, 0, true);
   }
 
+  // Combobox: typing filters the datalist locally; only an exact slug (or an empty box = all
+  // agents) is a real selection worth re-querying the server for.
+  function pickAgent(text: string) {
+    setAgentText(text);
+    const hit = agents.find((a) => a.slug === text);
+    if (hit) {
+      if (hit.id !== agentId) applyAgent(hit.id);
+    } else if (!text.trim() && agentId) {
+      applyAgent("");
+    }
+  }
+
   // Every filter refines the rows already loaded — none of them needs the server.
 
+
+  // Natural order, so agent_2 sorts before agent_10 instead of after it.
+  const sortedAgents = useMemo(
+    () => [...agents].sort((a, b) => a.slug.localeCompare(b.slug, undefined, { numeric: true, sensitivity: "base" })),
+    [agents],
+  );
 
   const counts = useMemo(
     () => ({
@@ -209,20 +229,21 @@ export function TracesExplorer({
             <span className="h-5 w-px bg-line" aria-hidden />
             <label className="flex items-center gap-2">
               <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-fg-faint">Agent</span>
-              <select
-                value={agentId}
-                onChange={(e) => applyAgent(e.target.value)}
+              <input
+                type="search"
+                list="traces-agent-slugs"
+                value={agentText}
+                onChange={(e) => pickAgent(e.target.value)}
                 disabled={loading}
+                placeholder="All agents"
                 aria-label="Filter by agent"
-                className="rounded-lg border border-line bg-ink-800 px-2 py-1.5 font-mono text-[12px] text-fg-muted transition-colors hover:text-fg focus:border-signal/40 focus:outline-none disabled:opacity-50"
-              >
-                <option value="">All agents</option>
-                {agents.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.slug}
-                  </option>
+                className="w-52 rounded-lg border border-line bg-ink-800 px-2 py-1.5 font-mono text-[12px] text-fg placeholder:text-fg-faint transition-colors focus:border-signal/40 focus:outline-none disabled:opacity-50"
+              />
+              <datalist id="traces-agent-slugs">
+                {sortedAgents.map((a) => (
+                  <option key={a.id} value={a.slug} />
                 ))}
-              </select>
+              </datalist>
             </label>
           </>
         )}

--- a/frontend/app/components/alerts/TriggerConfigForm.tsx
+++ b/frontend/app/components/alerts/TriggerConfigForm.tsx
@@ -3,6 +3,7 @@
 import clsx from "clsx";
 import type { AgentRow } from "@/app/lib/api";
 import { TRIGGERS, intervalLabel, type Draft, type TriggerId } from "@/app/lib/alerts";
+import { AgentPicker } from "../AgentPicker";
 import { FIELD, LABEL, TONE } from "./tone";
 
 /** The inspector for the **When** node: which event or threshold starts the flow, and how narrow.
@@ -58,19 +59,15 @@ export function TriggerConfigForm({
             <label htmlFor="tr-agent" className={LABEL}>
               Agent
             </label>
-            <select
+            <AgentPicker
               id="tr-agent"
+              agents={agents}
               value={draft.target_agent}
-              onChange={(e) => onChange({ target_agent: e.target.value })}
+              onChange={(v) => onChange({ target_agent: v })}
+              by="slug"
+              allLabel="all agents"
               className={FIELD}
-            >
-              <option value="">all agents</option>
-              {agents.map((a) => (
-                <option key={a.id} value={a.slug}>
-                  {a.slug}
-                </option>
-              ))}
-            </select>
+            />
           </div>
           <div className="space-y-1">
             <label htmlFor="tr-interval" className={LABEL}>

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -31,3 +31,8 @@ if (typeof window !== "undefined" && !window.localStorage) {
   Object.defineProperty(window, "localStorage", { value: localStorage, configurable: true });
   Object.defineProperty(globalThis, "localStorage", { value: localStorage, configurable: true });
 }
+
+// jsdom has no layout, so it ships no scrollIntoView — a no-op is the honest stand-in.
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
The agent <select> listed every registry agent in insertion order, so on a project with dozens of agents finding one meant scrolling a wall of options.

Swap it for a native combobox (<input type="search" list> + <datalist>): typing filters the list, an exact slug re-queries the server, an empty box falls back to all agents. Sort the options with localeCompare(numeric) so agent_2 comes before agent_10.

## What

<!-- One or two sentences. Link the issue: Closes #123 -->

## Why

<!-- The problem this solves, or the user-facing behavior it changes. -->

## How verified

<!-- Tests added/updated, manual steps, screenshots for UI changes. -->

## Checklist

- [ ] `uv run pytest -q backend/tests sdk/tests` passes
- [ ] `uv run ruff check . && uv run ruff format .` clean
- [ ] `cd frontend && pnpm test && pnpm build` passes (if frontend touched)
- [ ] Follows the hard rules in `CLAUDE.md` (no SQL in routers, LLM calls via `provider.py`, `project_id` scoping)
- [ ] New env var added to `config.py` **and** `docker-compose.yml` `x-app-env` (if any)
- [ ] `uv.lock` regenerated (if deps changed)
