### PR TITLE
fix(clickhouse): clamp negative `limit` in list readers alongside `offset`

### DIFF
--- a/backend/tracely/infrastructure/clickhouse/async_reader.py
+++ b/backend/tracely/infrastructure/clickhouse/async_reader.py
@@ -93,7 +93,7 @@ async def traces_overview(project_id: str, limit: int, advisory: Sequence[str] =
         ORDER BY ts DESC
         LIMIT {{n:UInt32}}
         """,
-        parameters={"p": project_id, "n": limit},
+        parameters={"p": project_id, "n": max(limit, 0)},
     )
     rows = [dict(zip(res.column_names, row)) for row in res.result_rows]
     ev = await client.query(
@@ -371,7 +371,7 @@ async def evaluator_score_queue(
         "AND ({v:String} = '' OR verdict = {v:String}) "
         "ORDER BY cityHash64(id) LIMIT {lim:UInt32} OFFSET {off:UInt32}",
         parameters={
-            "p": project_id, "n": name, "lim": limit, "off": max(offset, 0),
+            "p": project_id, "n": name, "lim": max(limit, 0), "off": max(offset, 0),
             "v": verdict.upper(),
         },
     )
@@ -454,7 +454,7 @@ async def sessions_overview(
     order_clause = session_order_clause(sort, order)
     time_clause = ""
     internal_clause = "" if include_internal else f" AND {_REAL}"
-    params: dict = {"p": project_id, "n": limit, "o": max(offset, 0), "adv": list(advisory)}
+    params: dict = {"p": project_id, "n": max(limit, 0), "o": max(offset, 0), "adv": list(advisory)}
     if from_ts:
         time_clause += " AND start_time >= parseDateTimeBestEffort({from:String})"
         params["from"] = from_ts

--- a/sdk/tracely_sdk/cli.py
+++ b/sdk/tracely_sdk/cli.py
@@ -31,8 +31,8 @@ from tracely_sdk.export import download_export
 
 MARKER = "<!-- tracely-gate -->"
 STATUS_CONTEXT = "tracely/regression-gate"
-ICON = {"PASS": "✓", "FAIL": "✗", "SKIP": "–", "NO_COVERAGE": "⚠", "UNGRADED": "⚠"}
-EMOJI = {"PASS": "✅", "FAIL": "❌", "SKIP": "⏭️", "NO_COVERAGE": "⚠️", "UNGRADED": "⚠️"}
+ICON = {"PASS": "✓", "FAIL": "✗", "ERROR": "✗", "SKIP": "–", "NO_COVERAGE": "⚠", "UNGRADED": "⚠"}
+EMOJI = {"PASS": "✅", "FAIL": "❌", "ERROR": "❌", "SKIP": "⏭️", "NO_COVERAGE": "⚠️", "UNGRADED": "⚠️"}
 
 
 # ── Tracely API ──────────────────────────────────────────────────────────────
@@ -144,7 +144,7 @@ def render_console(data: dict, sha: str) -> None:
     print(f"\n  Result: {data['status']}\n")
 
 
-_HEAD = {"FAIL": "🔴", "PASS": "🟢", "NO_COVERAGE": "🟠"}
+_HEAD = {"FAIL": "🔴", "ERROR": "🔴", "PASS": "🟢", "NO_COVERAGE": "🟠"}
 
 # Worst-wins across agents. Anything that isn't PASS blocks, but the headline should name the most
 # alarming thing that happened, not the first one alphabetically.


### PR DESCRIPTION
`sessions_overview`, `traces_overview` and `evaluator_score_queue` already clamp `offset` with `max(offset, 0)` but bound `limit` as-is into `LIMIT {n:UInt32}`. Neither router clamps and the frontend proxy forwards `limit` verbatim, so `GET /api/sessions?limit=-1` reached ClickHouse as a negative UInt32 and returned a 500. This wraps `limit` in `max(limit, 0)` beside the existing offset clamp in all three readers (`calibration_queue` goes through `evaluator_score_queue`). No router or frontend changes.

Closes #98