### PR TITLE
docs: fix stale root-level guide paths in CLAUDE.md and scripts/README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,6 @@ Each folder has a thorough README; read it before changing that area rather than
 | `backend/README.md` | Full flow walkthroughs (ingest, eval, failure intel, regression, gate, auth, rolling summary, meta-analysis), module map, API surface, schema/migration list. |
 | `frontend/README.md` | Data-flow rule, app shell, per-route fetch table, theme tokens. |
 | `sdk/README.md` | Auto + manual instrumentation, the `tracely.*` attributes the backend indexes, hermetic replay seam, CLI. |
-| `README.md`, `OVERVIEW.md`, `DEMO.md`, `DEPLOY.md` | Quickstart / guided tour / 2-min demo / Railway runbook. |
+| `README.md`, `guides/OVERVIEW.md`, `guides/DEMO.md`, `guides/DEPLOY.md` | Quickstart / guided tour / 2-min demo / Railway runbook. |
 | `design/` | The design dossier — the "why" behind every decision above. |
 | `docs/` | The published SDK docs site (Nextra, `make docs` → :3002). |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,7 +55,7 @@ docker compose --profile demo up -d --build --wait     # Docker: the `demo` comp
 docker compose exec backend python scripts/seed_demo.py   # seed an already-running stack
 ```
 
-Idempotent — each phase is skipped when its data already exists (promote dedupes by input digest; deterministic trace ids replace in place), so it's safe to run on every `docker compose up`. Pass `--force` to re-run anyway. This is the script behind [`DEMO.md`](../DEMO.md).
+Idempotent — each phase is skipped when its data already exists (promote dedupes by input digest; deterministic trace ids replace in place), so it's safe to run on every `docker compose up`. Pass `--force` to re-run anyway. This is the script behind [`DEMO.md`](../guides/DEMO.md).
 
 ## `tracely_gate.py` — deprecated shim
 


### PR DESCRIPTION
OVERVIEW.md, DEMO.md and DEPLOY.md moved to `guides/`, but two pointers still referenced the repo root. This updates the "Where the detail lives" table in `CLAUDE.md` and the `DEMO.md` link in `scripts/README.md` to the `guides/` paths, matching the top-level README.

Closes #102