### PR TITLE
fix(sdk): give GitHub API calls the CLI socket timeout

### DIFF
--- a/sdk/tests/test_cli_simulate.py
+++ b/sdk/tests/test_cli_simulate.py
@@ -322,3 +322,32 @@ def test_auth_hint_separates_a_missing_key_from_a_stale_one():
     stale = _auth_hint("https://api.example.com", "tk_rotated")
     assert "rotated" in stale
     assert "unset" not in stale, "a key that IS set must not be reported as missing"
+
+
+# ── GitHub API timeout ──────────────────────────────────────────────────────
+
+
+def test_github_call_passes_the_socket_timeout(monkeypatch):
+    """Without a timeout a hung GitHub connection hangs the CI job forever with no output
+    and no exit code (issue #90) — every `GitHub._call` must carry `_HTTP_TIMEOUT_S`."""
+    import io
+
+    calls = {}
+
+    class _Resp(io.BytesIO):
+        length = 2
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_urlopen(req, **kw):
+        calls.update(kw)
+        return _Resp(b"{}")
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", fake_urlopen)
+
+    assert cli.GitHub("tok")._call("POST", "/repos/o/r/statuses/abc", {"state": "success"}) == {}
+    assert calls.get("timeout") == cli._HTTP_TIMEOUT_S == 60

--- a/sdk/tracely_sdk/cli.py
+++ b/sdk/tracely_sdk/cli.py
@@ -345,7 +345,7 @@ class GitHub:
             },
         )
         try:
-            with urllib.request.urlopen(req) as r:
+            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as r:
                 return json.load(r) if r.length != 0 else {}
         except urllib.error.HTTPError as e:
             print(f"github {method} {path} -> {e.code}: {e.read().decode()[:300]}")


### PR DESCRIPTION
## What

Passes `timeout=_HTTP_TIMEOUT_S` (60s) in `GitHub._call` (`sdk/tracely_sdk/cli.py`). Closes #90.

## Why

`_get_json`/`_post_json` already carry the 60s socket timeout, but `GitHub._call` called `urlopen(req)` with no timeout, so posting the commit status / PR comment could hang the CI job forever after the gate already had its verdict.

## How verified

- New test `test_github_call_passes_the_socket_timeout` in `sdk/tests/test_cli_simulate.py`: RED before fix (timeout kwarg absent), GREEN after.
- `pytest -q sdk/tests`: 122 passed, 6 skipped.
- `ruff check sdk/tracely_sdk/cli.py sdk/tests/test_cli_simulate.py`: clean.
- Note: verified in an isolated venv (project `uv run` cannot sync onnxruntime on Python 3.14); CI is final arbiter. `ruff format --check` drift on both files is pre-existing, so formatting was left untouched to keep the diff minimal.

## Checklist

- [x] `uv run pytest -q backend/tests sdk/tests` passes (via equivalent isolated venv for sdk/tests; see note)
- [x] `uv run ruff check . && uv run ruff format .` clean (check clean; format drift pre-existing, untouched)
- [ ] `cd frontend && pnpm test && pnpm build` passes (if frontend touched) — N/A, SDK only
- [x] Follows the hard rules in `CLAUDE.md` (SDK CLI stays stdlib-only)
- [ ] New env var added to `config.py` **and** `docker-compose.yml` `x-app-env` (if any) — N/A
- [ ] `uv.lock` regenerated (if deps changed) — N/A