### PR TITLE
fix(backend): use timeout-bounded Redis client in auth rate limiter

### DIFF
--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -25,7 +25,7 @@ class DeadRedis:
 
 async def test_login_is_limited_per_ip(client, monkeypatch):
     fake = FakeRedis()
-    monkeypatch.setattr(ratelimit, "_get_client", lambda: fake)
+    monkeypatch.setattr(ratelimit, "sync_redis", lambda: fake)
     bad = {"email": "nobody@x.test", "password": "wrong-wrong"}
     for _ in range(20):
         assert (await client.post("/auth/login", json=bad)).status_code == 401
@@ -38,7 +38,7 @@ async def test_login_is_limited_per_ip(client, monkeypatch):
 
 
 async def test_redis_outage_fails_open(client, monkeypatch):
-    monkeypatch.setattr(ratelimit, "_get_client", lambda: DeadRedis())
+    monkeypatch.setattr(ratelimit, "sync_redis", lambda: DeadRedis())
     bad = {"email": "nobody@x.test", "password": "wrong-wrong"}
     for _ in range(25):
         assert (await client.post("/auth/login", json=bad)).status_code == 401

--- a/backend/tracely/api/ratelimit.py
+++ b/backend/tracely/api/ratelimit.py
@@ -21,7 +21,7 @@ import structlog
 from fastapi import HTTPException, Request
 from starlette.concurrency import run_in_threadpool
 
-from tracely.infrastructure.queue.eval_debounce import _get_client
+from tracely.infrastructure.redis_client import sync_redis
 
 log = structlog.get_logger()
 
@@ -39,7 +39,7 @@ def hits(name: str, ip: str) -> int | None:
     """Count this request and return the window's total, or None when Redis is unavailable."""
     key = f"tracely:rl:{name}:{ip}"
     try:
-        r = _get_client()
+        r = sync_redis()
         n = r.incr(key)
         if n == 1:
             r.expire(key, WINDOW_SECONDS)


### PR DESCRIPTION
## What

Replaces the private timeout-less `_get_client` (from `tracely.infrastructure.queue.eval_debounce`) with the shared `sync_redis()` (`tracely.infrastructure.redis_client`, 0.2s socket timeouts) in `backend/tracely/api/ratelimit.py::hits()`. Test patch targets updated accordingly. Closes #58.

## Why

The auth rate limiter runs per-request on login/register/reset behind `run_in_threadpool` and promises to fail open, but a down Redis pinned a threadpool thread for the OS connect timeout instead of milliseconds. The shared client exists for exactly this.

## How verified

- TDD: updated tests to patch `ratelimit.sync_redis` first → RED (`AttributeError: has no attribute 'sync_redis'`), then 2-line source fix → GREEN.
- `uv run --python 3.12 pytest -q backend/tests/test_ratelimit.py -x`: 2 passed.
- `uv run --python 3.12 pytest -q backend/tests sdk/tests`: 1031 passed, 34 skipped.
- `uv run --python 3.12 ruff check .`: All checks passed.
- Note: `ruff format --check` flags one pre-existing long line in `test_ratelimit.py:35` (verified on clean origin/master via stash), left untouched to keep the diff minimal.

## Checklist

- [x] `uv run pytest -q backend/tests sdk/tests` passes (via `--python 3.12` matching CI)
- [x] `uv run ruff check . && uv run ruff format .` clean (check clean; one pre-existing format drift untouched)
- [ ] `cd frontend && pnpm test && pnpm build` passes (if frontend touched) — N/A, backend only
- [x] Follows the hard rules in `CLAUDE.md` (sync redis stays in `run_in_threadpool`, fail-open preserved)
- [ ] New env var added to `config.py` **and** `docker-compose.yml` `x-app-env` (if any) — N/A
- [ ] `uv.lock` regenerated (if deps changed) — N/A